### PR TITLE
fix: русскоязычный промпт + прокси для Groq API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build: .
     container_name: beebot
     restart: unless-stopped
+    network_mode: host
     env_file:
       - .env
     volumes:

--- a/groq_proxy.py
+++ b/groq_proxy.py
@@ -1,0 +1,45 @@
+"""Simple reverse proxy for Groq API to bypass IP restrictions."""
+
+import asyncio
+import logging
+
+import aiohttp
+from aiohttp import web
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+GROQ_BASE = "https://api.groq.com"
+LISTEN_PORT = 8990
+
+
+async def proxy_handler(request: web.Request) -> web.Response:
+    """Forward request to Groq API."""
+    target_url = f"{GROQ_BASE}{request.path_qs}"
+    headers = dict(request.headers)
+    headers.pop("Host", None)
+
+    body = await request.read()
+    logger.info(f"Proxy: {request.method} {request.path}")
+
+    async with aiohttp.ClientSession() as session:
+        async with session.request(
+            method=request.method,
+            url=target_url,
+            headers=headers,
+            data=body,
+        ) as resp:
+            response_body = await resp.read()
+            return web.Response(
+                status=resp.status,
+                body=response_body,
+                content_type=resp.content_type,
+            )
+
+
+app = web.Application()
+app.router.add_route("*", "/{path:.*}", proxy_handler)
+
+if __name__ == "__main__":
+    logger.info(f"Starting Groq proxy on port {LISTEN_PORT}")
+    web.run_app(app, host="0.0.0.0", port=LISTEN_PORT)

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,7 @@ TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
 # Groq
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")
 GROQ_MODEL = os.getenv("GROQ_MODEL", "llama-3.3-70b-versatile")
+GROQ_BASE_URL = os.getenv("GROQ_BASE_URL")  # Optional proxy URL
 
 # Embeddings
 EMBEDDING_MODEL = os.getenv(

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -4,7 +4,7 @@ import logging
 
 from groq import Groq
 
-from src.config import GROQ_API_KEY, GROQ_MODEL, MAX_RESPONSE_LENGTH
+from src.config import GROQ_API_KEY, GROQ_MODEL, GROQ_BASE_URL, MAX_RESPONSE_LENGTH
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +18,7 @@ SYSTEM_PROMPT = """Ты — Александр Дмитров, пчеловод 
 - Конкретные практические советы с дозировками и рецептами
 
 Правила:
+- ВСЕГДА отвечай ТОЛЬКО на русском языке. Никогда не используй слова на других языках.
 - Отвечай на основе предоставленного контекста из своих видео и инструкций
 - Если информации в контексте недостаточно — честно скажи об этом
 - Не придумывай дозировки или рецепты, которых нет в контексте
@@ -49,7 +50,10 @@ class LLMClient:
     """Client for generating responses via Groq."""
 
     def __init__(self):
-        self.client = Groq(api_key=GROQ_API_KEY)
+        kwargs = {"api_key": GROQ_API_KEY}
+        if GROQ_BASE_URL:
+            kwargs["base_url"] = GROQ_BASE_URL
+        self.client = Groq(**kwargs)
         self.model = GROQ_MODEL
 
     def generate(self, query: str, context_chunks: list[dict]) -> str:
@@ -64,7 +68,7 @@ class LLMClient:
                     {"role": "user", "content": user_prompt},
                 ],
                 max_tokens=MAX_RESPONSE_LENGTH,
-                temperature=0.7,
+                temperature=0.5,
             )
             return response.choices[0].message.content
 


### PR DESCRIPTION
## Summary
- Исправлены иноязычные вставки в ответах бота (французские/вьетнамские слова)
- Добавлен Groq proxy для обхода IP-блокировки на VPS
- Снижена temperature для стабильности

## Изменения
- `src/llm_client.py` — правило "ТОЛЬКО на русском языке", temperature 0.5, поддержка GROQ_BASE_URL
- `src/config.py` — новая переменная GROQ_BASE_URL
- `docker-compose.yml` — network_mode: host для доступа к SSH-туннелю
- `groq_proxy.py` — reverse proxy для Groq API

🤖 Generated with [Claude Code](https://claude.com/claude-code)