### PR TITLE
fix: groq-tunnel использует SSH алиас beebot-vps

### DIFF
--- a/systemd/groq-tunnel.service
+++ b/systemd/groq-tunnel.service
@@ -10,12 +10,9 @@ User=hive
 # Exposes hive's local port 8990 as port 8990 on the VPS
 ExecStart=/usr/bin/ssh \
     -N \
-    -o ServerAliveInterval=30 \
-    -o ServerAliveCountMax=3 \
     -o ExitOnForwardFailure=yes \
-    -o StrictHostKeyChecking=accept-new \
     -R 8990:localhost:8990 \
-    root@185.233.200.13
+    beebot-vps
 Restart=always
 RestartSec=10
 StandardOutput=journal


### PR DESCRIPTION
## Summary

- `groq-tunnel.service`: заменён прямой `root@185.233.200.13` на алиас `beebot-vps` из `~/.ssh/config`
- `ServerAliveInterval`/`ServerAliveCountMax` вынесены в SSH config (алиас), убраны из ExecStart для чистоты
- Пользователь VPS исправлен на `ai-agent` (через алиас) — ранее было `root`, что не работало

## Chunking (задеплоено вне git)

Новая стратегия чанкинга вступила в силу — индекс пересобран:
- **Было:** 421 чанк (chunk_size=600)
- **Стало:** 244 чанка (PDF: 900/150, YouTube: 1200/250)
- Каждый чанк содержит больше контекста → меньше обрывов посреди инструкций

## Test plan

- [ ] `systemctl status groq-tunnel` — active (running)
- [ ] `ssh beebot-vps echo ok` — соединение через алиас работает
- [ ] Бот отвечает на вопрос о продукте — контекст в ответе полный, не обрывается

🤖 Generated with [Claude Code](https://claude.com/claude-code)