### PR TITLE
fix: порт веб-панели 8088 (8080 занят)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     container_name: beebot-web
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "8088:8080"
     env_file:
       - .env
     logging:


### PR DESCRIPTION
## Summary
- Порт веб-панели изменён с 8080 на 8088 в docker-compose.yml
- На VPS порт 8080 занят контейнером traderagent-bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)