### PR TITLE
fix: OOM — CPU-only torch до requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Python dependencies
+# Install PyTorch CPU-only FIRST (before requirements.txt pulls CUDA version)
+RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
+
+# Python dependencies (torch already installed — pip will skip it)
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-
-# Install PyTorch CPU-only (smaller image)
-RUN pip install --no-cache-dir torch --index-url https://download.pytorch.org/whl/cpu
 
 # Download embedding model at build time
 RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2')"


### PR DESCRIPTION
## Summary
- Бот падал с OOM на VPS (2 ГБ RAM) — torch с CUDA занимал ~3 ГБ
- Перестроен порядок установки в Dockerfile: CPU-only torch ставится **до** `requirements.txt`
- Это предотвращает скачивание CUDA-библиотек и уменьшает образ на ~2.5 ГБ

## Test plan
- [ ] `docker compose up -d --build beebot` — контейнер стартует без OOM
- [ ] `docker logs beebot` — видны логи "Knowledge base loaded", "Integram CRM подключена"

🤖 Generated with [Claude Code](https://claude.com/claude-code)