### PR TITLE
fix: on_startup kwargs (aiogram)

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -957,7 +957,7 @@ async def _alert(text: str) -> None:
 
 
 @dp.startup()
-async def on_startup(_: Bot) -> None:
+async def on_startup(**_kwargs) -> None:
     """Отправить алерт о старте после установки соединения с Telegram."""
     await _alert("🟢 BEEBOT запущен")
 


### PR DESCRIPTION
Исправлена сигнатура on_startup — aiogram передаёт bot= как keyword-arg, а не positional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)