### PR TITLE
fix: Telegram SOCKS5 прокси — обход блокировки api.telegram.org

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,10 @@ INTEGRAM_DB=your_integram_db_here
 # Groq API proxy (необязательно — для обхода блокировки IP)
 # GROQ_BASE_URL=http://localhost:8990
 
+# Telegram SOCKS5 proxy (необязательно — если VPS блокирует api.telegram.org)
+# Настройка: запустить tg-socks.service на hive + добавить в groq-tunnel.service -R 9150:localhost:9150
+# TG_SOCKS_PROXY=socks5://localhost:9150
+
 # Веб-панель (обязательно!)
 WEB_PASSWORD=your_strong_password_here
 # WEB_SECRET=your_jwt_secret_here  # если не задан — генерируется при каждом запуске

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Telegram bot
 aiogram==3.25.0
+aiohttp-socks>=0.8,<1.0
 
 # AI / LLM
 groq==1.0.0

--- a/src/bot.py
+++ b/src/bot.py
@@ -18,7 +18,7 @@ from aiogram.types import (
     ReplyKeyboardRemove,
 )
 
-from src.config import TELEGRAM_BOT_TOKEN, BASE_DIR, PDFS_DIR, BEEKEEPER_CHAT_ID, ADMIN_CHAT_ID
+from src.config import TELEGRAM_BOT_TOKEN, BASE_DIR, PDFS_DIR, BEEKEEPER_CHAT_ID, ADMIN_CHAT_ID, TG_SOCKS_PROXY
 from src.phone_utils import validate_phone, format_phone
 from src.delivery.tracker import OrderTracker
 from src.integrations.uds import UDSClient, UDSPoller
@@ -52,7 +52,14 @@ logger = logging.getLogger(__name__)
 # «Голос Улья» — стиль ответов, выбранный пользователем (user_id → style_id)
 _user_styles: dict[int, str] = {}
 
-bot = Bot(token=TELEGRAM_BOT_TOKEN)
+if TG_SOCKS_PROXY:
+    from aiohttp_socks import ProxyConnector
+    from aiogram.client.session.aiohttp import AiohttpSession
+    _session = AiohttpSession(connector=ProxyConnector.from_url(TG_SOCKS_PROXY))
+    bot = Bot(token=TELEGRAM_BOT_TOKEN, session=_session)
+    logger.info("Telegram via SOCKS5 proxy: %s", TG_SOCKS_PROXY)
+else:
+    bot = Bot(token=TELEGRAM_BOT_TOKEN)
 dp = Dispatcher(storage=MemoryStorage())
 
 # Админ-роутер регистрируется первым — его команды имеют приоритет

--- a/src/config.py
+++ b/src/config.py
@@ -8,6 +8,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Telegram
 TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN")
+# SOCKS5 прокси для обхода блокировки api.telegram.org (если VPS не может достучаться)
+# Настроить совместно с tg-socks.service + groq-tunnel.service на hive
+TG_SOCKS_PROXY = os.getenv("TG_SOCKS_PROXY")  # e.g. socks5://localhost:9150
 
 # Groq
 GROQ_API_KEY = os.getenv("GROQ_API_KEY")

--- a/systemd/groq-tunnel.service
+++ b/systemd/groq-tunnel.service
@@ -1,17 +1,20 @@
 [Unit]
-Description=SSH Reverse Tunnel to VPS (BEEBOT Groq proxy)
-After=network-online.target groq-proxy.service
+Description=SSH Reverse Tunnels to VPS (BEEBOT Groq proxy + Telegram SOCKS5)
+After=network-online.target groq-proxy.service tg-socks.service
 Wants=network-online.target
-Requires=groq-proxy.service
+Requires=groq-proxy.service tg-socks.service
 
 [Service]
 Type=simple
 User=hive
-# Exposes hive's local port 8990 as port 8990 on the VPS
+# Exposes hive's local ports on the VPS:
+#   8990 → groq-proxy (Groq API)
+#   9150 → tg-socks (Telegram SOCKS5 proxy)
 ExecStart=/usr/bin/ssh \
     -N \
     -o ExitOnForwardFailure=yes \
     -R 8990:localhost:8990 \
+    -R 9150:localhost:9150 \
     beebot-vps
 Restart=always
 RestartSec=10

--- a/systemd/install-hive-services.sh
+++ b/systemd/install-hive-services.sh
@@ -30,20 +30,24 @@ fi
 # Install services
 echo "Copying service files to /etc/systemd/system/..."
 cp "$SCRIPT_DIR/groq-proxy.service" /etc/systemd/system/
+cp "$SCRIPT_DIR/tg-socks.service" /etc/systemd/system/
 cp "$SCRIPT_DIR/groq-tunnel.service" /etc/systemd/system/
 
 # Reload and enable
 systemctl daemon-reload
-systemctl enable groq-proxy groq-tunnel
-systemctl restart groq-proxy groq-tunnel
+systemctl enable groq-proxy tg-socks groq-tunnel
+systemctl restart groq-proxy tg-socks groq-tunnel
 
 echo ""
 echo "=== Done ==="
 systemctl status groq-proxy --no-pager -l
 echo "---"
+systemctl status tg-socks --no-pager -l
+echo "---"
 systemctl status groq-tunnel --no-pager -l
 echo ""
 echo "Useful commands:"
-echo "  journalctl -u groq-proxy -f    # proxy logs"
-echo "  journalctl -u groq-tunnel -f   # tunnel logs"
+echo "  journalctl -u groq-proxy -f    # Groq proxy logs"
+echo "  journalctl -u tg-socks -f      # Telegram SOCKS5 proxy logs"
+echo "  journalctl -u groq-tunnel -f   # SSH tunnel logs"
 echo "  systemctl restart groq-tunnel  # restart after VPS reboot"

--- a/systemd/tg-socks.service
+++ b/systemd/tg-socks.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=SOCKS5 proxy for Telegram Bot API (BEEBOT)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=hive
+WorkingDirectory=/home/hive/BEEBOT
+ExecStart=/home/hive/BEEBOT/.venv/bin/python tg_socks_proxy.py
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=tg-socks
+
+[Install]
+WantedBy=multi-user.target

--- a/tg_socks_proxy.py
+++ b/tg_socks_proxy.py
@@ -1,0 +1,111 @@
+"""Minimal async SOCKS5 proxy for Telegram Bot API access from VPS.
+
+VPS cannot reach api.telegram.org directly (TLS timeout at hosting provider).
+This proxy runs on hive (which HAS internet access), and is exposed to the VPS
+via SSH reverse tunnel (see systemd/groq-tunnel.service).
+
+Listen: localhost:9150 (SOCKS5, no auth)
+Usage (bot side): set TG_SOCKS_PROXY=socks5://localhost:9150 in .env
+"""
+
+import asyncio
+import logging
+import struct
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+LISTEN_HOST = "127.0.0.1"
+LISTEN_PORT = 9150
+
+
+async def _pipe(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    try:
+        while not reader.at_eof():
+            data = await reader.read(65536)
+            if not data:
+                break
+            writer.write(data)
+            await writer.drain()
+    except Exception:
+        pass
+    finally:
+        try:
+            writer.close()
+        except Exception:
+            pass
+
+
+async def _handle(client_r: asyncio.StreamReader, client_w: asyncio.StreamWriter) -> None:
+    try:
+        # ── Greeting ──────────────────────────────────────────────────────────
+        hdr = await client_r.read(2)
+        if len(hdr) < 2 or hdr[0] != 0x05:
+            return
+        nmethods = hdr[1]
+        await client_r.read(nmethods)          # skip auth method list
+        client_w.write(b"\x05\x00")            # no-auth
+        await client_w.drain()
+
+        # ── Request ───────────────────────────────────────────────────────────
+        req = await client_r.read(4)
+        if len(req) < 4 or req[0] != 0x05 or req[1] != 0x01:  # only CONNECT
+            client_w.write(b"\x05\x07\x00\x01" + b"\x00" * 6)
+            await client_w.drain()
+            return
+
+        atyp = req[3]
+        if atyp == 0x01:                       # IPv4
+            raw = await client_r.read(4)
+            host = ".".join(str(b) for b in raw)
+        elif atyp == 0x03:                     # domain name
+            alen = (await client_r.read(1))[0]
+            host = (await client_r.read(alen)).decode()
+        elif atyp == 0x04:                     # IPv6
+            import socket
+            raw = await client_r.read(16)
+            host = socket.inet_ntop(socket.AF_INET6, raw)
+        else:
+            client_w.write(b"\x05\x08\x00\x01" + b"\x00" * 6)
+            await client_w.drain()
+            return
+
+        port = struct.unpack("!H", await client_r.read(2))[0]
+
+        # ── Connect to target ─────────────────────────────────────────────────
+        try:
+            remote_r, remote_w = await asyncio.open_connection(host, port)
+        except Exception as e:
+            logger.warning("Connect failed %s:%d — %s", host, port, e)
+            client_w.write(b"\x05\x04\x00\x01" + b"\x00" * 6)
+            await client_w.drain()
+            return
+
+        # ── Success ───────────────────────────────────────────────────────────
+        client_w.write(b"\x05\x00\x00\x01" + b"\x00" * 4 + b"\x00\x00")
+        await client_w.drain()
+
+        logger.info("Tunnel: %s:%d", host, port)
+        await asyncio.gather(
+            _pipe(client_r, remote_w),
+            _pipe(remote_r, client_w),
+        )
+
+    except Exception as e:
+        logger.error("Handler error: %s", e)
+    finally:
+        try:
+            client_w.close()
+        except Exception:
+            pass
+
+
+async def main() -> None:
+    server = await asyncio.start_server(_handle, LISTEN_HOST, LISTEN_PORT)
+    logger.info("SOCKS5 proxy listening on %s:%d", LISTEN_HOST, LISTEN_PORT)
+    async with server:
+        await server.serve_forever()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Проблема

VPS блокирует TLS к api.telegram.org (TCP OK, SSL handshake зависает). Бот молчал, в логах: `TelegramNetworkError: Request timeout error`.

## Решение

Та же схема что для Groq API:
1. SOCKS5-прокси на hive (`tg_socks_proxy.py`, порт 9150, pure Python asyncio)
2. SSH reverse tunnel `-R 9150:localhost:9150` (добавлен в `groq-tunnel.service`)
3. aiogram `Bot` инициализируется с `ProxyConnector` если задан `TG_SOCKS_PROXY`

## Изменения

- `tg_socks_proxy.py` — минимальный SOCKS5-сервер (~100 строк, нет новых зависимостей на hive)
- `systemd/tg-socks.service` — systemd-сервис для hive
- `systemd/groq-tunnel.service` — добавлен `-R 9150:localhost:9150`
- `systemd/install-hive-services.sh` — устанавливает tg-socks вместе с groq-proxy
- `src/bot.py` — `Bot` с `ProxyConnector` если `TG_SOCKS_PROXY` задан
- `src/config.py` — переменная `TG_SOCKS_PROXY`
- `requirements.txt` — `aiohttp-socks>=0.8`

## Активация

```bash
# 1. На hive — один раз
sudo bash systemd/install-hive-services.sh

# 2. На VPS добавить в .env
TG_SOCKS_PROXY=socks5://localhost:9150

# 3. Пересобрать бота
docker compose up -d --build beebot
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)