### PR TITLE
feat: /teach команда + server-side пагинация Orders/Clients

### DIFF
--- a/src/admin.py
+++ b/src/admin.py
@@ -36,13 +36,15 @@ ORDER_STATUSES = ["Новый", "Подтверждён", "В сборке", "О
 _crm: Optional[IntegramClient] = None
 _notifier: Optional[Notifier] = None
 _bot: Optional[Bot] = None
+_kb = None  # KnowledgeBase — передаётся из bot.py
 
 
-def setup_admin(bot: Bot, crm: Optional[IntegramClient] = None) -> None:
+def setup_admin(bot: Bot, crm: Optional[IntegramClient] = None, kb=None) -> None:
     """Инициализировать админ-модуль с зависимостями."""
-    global _crm, _notifier, _bot
+    global _crm, _notifier, _bot, _kb
     _bot = bot
     _crm = crm
+    _kb = kb
     _notifier = Notifier(bot)
 
 
@@ -531,6 +533,56 @@ async def _get_client_telegram_id_from_order(order_id: int) -> Optional[int]:
         return await _get_client_telegram_id(order.client_id)
     except Exception:
         return None
+
+
+# ---------------------------------------------------------------------------
+# /teach <текст> — добавить знание в базу знаний
+# ---------------------------------------------------------------------------
+
+
+@router.message(Command("teach"))
+async def cmd_teach(message: types.Message) -> None:
+    """Добавить новый чанк в FAISS без полной пересборки (только для админа)."""
+    if not _is_admin(message.from_user.id):
+        await message.answer("Команда доступна только администратору.")
+        return
+
+    if _kb is None:
+        await message.answer("База знаний не подключена.")
+        return
+
+    text = (message.text or "").removeprefix("/teach").strip()
+
+    if not text:
+        await message.answer(
+            "Использование: /teach <текст>\n\n"
+            "Добавляет новый фрагмент знаний в базу поиска без полной пересборки.\n"
+            "Минимум 40 символов."
+        )
+        return
+
+    try:
+        from datetime import date
+        source = f"admin:teach:{date.today().isoformat()}"
+        chunk = _kb.teach(text, source=source)
+        total = len(_kb.chunks)
+        preview = text[:120] + ("..." if len(text) > 120 else "")
+        await message.answer(
+            f"✅ Знание добавлено в базу.\n\n"
+            f"📌 Источник: `{chunk['source']}`\n"
+            f"🔢 Чанков в индексе: {total}\n\n"
+            f"_{preview}_",
+            parse_mode="Markdown",
+        )
+        logger.info(
+            "admin:teach — чанк #%d добавлен (%d символов), total=%d",
+            chunk["chunk_index"], len(text), total,
+        )
+    except ValueError as e:
+        await message.answer(f"Ошибка: {e}")
+    except Exception as e:
+        logger.exception("Ошибка /teach: %s", e)
+        await message.answer(f"Не удалось добавить знание: {e}")
 
 
 async def _notify_status_change(order_id: int, new_status: str) -> None:

--- a/src/bot.py
+++ b/src/bot.py
@@ -1263,7 +1263,7 @@ async def main():
         logger.info("Integram CRM не настроена — агенты работают без CRM.")
 
     # Инициализировать админ-модуль (один раз, с CRM если доступна)
-    setup_admin(bot, crm=integram_client)
+    setup_admin(bot, crm=integram_client, kb=orchestrator._beebot.kb)
 
     # --- Авто-трекинг: фоновая проверка статуса отправлений ---
     order_tracker: Optional[OrderTracker] = None

--- a/src/knowledge_base.py
+++ b/src/knowledge_base.py
@@ -160,6 +160,55 @@ class KnowledgeBase:
         with open(CHUNKS_PATH, "w", encoding="utf-8") as f:
             json.dump(self.chunks, f, ensure_ascii=False, indent=2)
 
+    def teach(self, text: str, source: str = "admin:teach") -> dict:
+        """Добавить один чанк в FAISS без полной пересборки.
+
+        Args:
+            text:   Текст нового знания (минимум 40 символов).
+            source: Метка источника, например «admin:teach:2026-03-23».
+
+        Returns:
+            Добавленный чанк (dict с ключами text, source, chunk_index, added_at).
+
+        Raises:
+            ValueError: Если текст короткий или индекс не загружен.
+        """
+        from datetime import datetime, timezone
+
+        text = text.strip()
+        if len(text) < 40:
+            raise ValueError(f"Текст слишком короткий ({len(text)} символов). Минимум 40.")
+        if self.index is None:
+            raise ValueError("База знаний не загружена.")
+
+        self._load_model()
+
+        chunk_index = len(self.chunks)
+        chunk = {
+            "text": text,
+            "source": source,
+            "chunk_index": chunk_index,
+            "added_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        # Векторизация точно как в build()
+        sem_emb = self._encode([text], normalize=True)          # (1, semantic_dim)
+        style_vec = self.style_analyzer.to_vector(text)         # (5,)
+        norm = np.linalg.norm(style_vec)
+        if norm > 0:
+            style_vec = style_vec / norm
+        combined = np.hstack([
+            sem_emb * 0.7,
+            style_vec.reshape(1, -1) * 0.3,
+        ]).astype(np.float32)
+        faiss.normalize_L2(combined)
+
+        self.index.add(combined)
+        self.chunks.append(chunk)
+        self._save()
+
+        return chunk
+
     def load(self):
         """Load FAISS index, chunks, and embedding model from disk."""
         self.index = faiss.read_index(str(FAISS_INDEX_PATH))

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -77,7 +77,13 @@ export async function getReference() {
 
 export async function getOrders(params = {}) {
   const { data } = await http.get('/orders', { params: { per_page: 1000, ...params } })
-return data.items ?? data
+  return data.items ?? data
+}
+
+// Paginated version for OrdersView — returns { items, total, page, per_page }
+export async function getOrdersPaged(params = {}) {
+  const { data } = await http.get('/orders', { params: { per_page: 20, ...params } })
+  return data
 }
 
 export async function getOrder(id) {
@@ -138,6 +144,12 @@ export async function deleteOrderItem(orderId, itemId) {
 export async function getClients() {
   const { data } = await http.get('/clients', { params: { per_page: 1000 } })
   return data.items ?? data
+}
+
+// Paginated version for ClientsView — returns { items, total, page, per_page }
+export async function getClientsPaged(params = {}) {
+  const { data } = await http.get('/clients', { params: { per_page: 25, ...params } })
+  return data
 }
 
 export async function getClient(id) {

--- a/web/src/views/ClientsView.vue
+++ b/web/src/views/ClientsView.vue
@@ -6,18 +6,18 @@
       <DataTable
         :value="clients"
         :loading="loading"
+        lazy
         paginator
         :rows="25"
+        :total-records="total"
         row-hover
-        filter-display="row"
-        :global-filter-fields="['name', 'phone', 'city']"
-        v-model:filters="filters"
         class="text-sm"
+        @page="onPage"
         @row-click="(e) => $router.push(`/clients/${e.data.id}`)"
       >
         <template #header>
           <div class="flex justify-between items-center p-1">
-            <span class="text-base font-semibold text-gray-700">{{ clients.length }} клиентов</span>
+            <span class="text-base font-semibold text-gray-700">{{ total }} клиентов</span>
             <div class="flex gap-2 items-center">
               <IconField>
                 <InputIcon class="pi pi-search" />
@@ -25,6 +25,7 @@
                   v-model="searchQuery"
                   placeholder="Поиск по имени, телефону, городу"
                   class="w-64"
+                  @input="onSearch"
                 />
               </IconField>
               <Button
@@ -67,39 +68,45 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import DataTable from 'primevue/datatable'
 import Column from 'primevue/column'
 import InputText from 'primevue/inputtext'
 import IconField from 'primevue/iconfield'
 import InputIcon from 'primevue/inputicon'
 import Tag from 'primevue/tag'
-import { getClients, exportClients } from '../api.js'
+import { getClientsPaged, exportClients } from '../api.js'
 
 const loading = ref(true)
 const exporting = ref(false)
-const allClients = ref([])
+const clients = ref([])
+const total = ref(0)
 const searchQuery = ref('')
-const filters = ref({})
+let searchTimer = null
 
-const clients = computed(() => {
-  const q = searchQuery.value.toLowerCase()
-  if (!q) return allClients.value
-  return allClients.value.filter(
-    (c) =>
-      c.name?.toLowerCase().includes(q) ||
-      c.phone?.includes(q) ||
-      c.city?.toLowerCase().includes(q)
-  )
-})
+onMounted(() => loadClients())
 
-onMounted(async () => {
+async function loadClients(page = 1) {
+  loading.value = true
   try {
-    allClients.value = await getClients()
+    const params = { page }
+    if (searchQuery.value) params.search = searchQuery.value
+    const result = await getClientsPaged(params)
+    clients.value = result.items ?? result
+    total.value = result.total ?? clients.value.length
   } finally {
     loading.value = false
   }
-})
+}
+
+function onPage(event) {
+  loadClients(event.page + 1)
+}
+
+function onSearch() {
+  clearTimeout(searchTimer)
+  searchTimer = setTimeout(() => loadClients(1), 400)
+}
 
 async function doExport() {
   exporting.value = true

--- a/web/src/views/OrdersView.vue
+++ b/web/src/views/OrdersView.vue
@@ -16,7 +16,7 @@
         option-value="value"
         placeholder="Статус"
         class="w-44"
-        @change="loadOrders"
+        @change="loadOrders(1)"
       />
       <Select
         v-model="filterSource"
@@ -25,7 +25,7 @@
         option-value="value"
         placeholder="Источник"
         class="w-44"
-        @change="loadOrders"
+        @change="loadOrders(1)"
       />
       <span class="flex-1" />
       <Button
@@ -50,10 +50,13 @@
       <DataTable
         :value="orders"
         :loading="loading"
+        lazy
         paginator
         :rows="20"
+        :total-records="total"
         row-hover
         class="text-sm"
+        @page="onPage"
         @row-click="(e) => $router.push(`/orders/${e.data.id}`)"
       >
         <template #empty>
@@ -107,13 +110,15 @@ import DataTable from 'primevue/datatable'
 import Column from 'primevue/column'
 import Button from 'primevue/button'
 import Select from 'primevue/select'
-import { getOrders, getReference, exportOrders } from '../api.js'
+import { getOrdersPaged, getReference, exportOrders } from '../api.js'
 import StatusBadge from '../components/StatusBadge.vue'
 import { formatDate, formatMoney } from '../utils.js'
 
 const loading = ref(true)
 const exporting = ref(false)
 const orders = ref([])
+const total = ref(0)
+const currentPage = ref(1)
 const filterStatus = ref('')
 const filterSource = ref('')
 const statusOptions = ref([])
@@ -126,22 +131,29 @@ onMounted(async () => {
   await loadOrders()
 })
 
-async function loadOrders() {
+async function loadOrders(page = 1) {
   loading.value = true
   try {
-    const params = {}
+    const params = { page }
     if (filterStatus.value) params.status = filterStatus.value
     if (filterSource.value) params.source = filterSource.value
-    orders.value = await getOrders(params)
+    const result = await getOrdersPaged(params)
+    orders.value = result.items ?? result
+    total.value = result.total ?? orders.value.length
+    currentPage.value = page
   } finally {
     loading.value = false
   }
 }
 
+function onPage(event) {
+  loadOrders(event.page + 1)
+}
+
 function resetFilters() {
   filterStatus.value = ''
   filterSource.value = ''
-  loadOrders()
+  loadOrders(1)
 }
 
 async function doExport() {


### PR DESCRIPTION
## /teach — обучение бота (3.3)

`/teach <текст>` для ADMIN_CHAT_ID — добавляет чанк в FAISS без пересборки:
- `KnowledgeBase.teach()`: encode → index.add → chunks.append → _save
- Векторизация идентична `build()`: 70% семантика + 30% стилометрия
- `source = admin:teach:YYYY-MM-DD`
- `setup_admin(kb=...)` — KB передаётся из bot.py

## Пагинация (3.5)

- `getOrdersPaged()` / `getClientsPaged()` — возвращают `{items, total, page, per_page}`
- `OrdersView`: lazy DataTable, 20 заказов/стр, фильтры сбрасывают на стр. 1
- `ClientsView`: lazy DataTable, 25 клиентов/стр, debounced поиск через `?search=`
- `getOrders(per_page=1000)` и `getClients(per_page=1000)` — сохранены для PackingView/DashboardView/MonthlyOrdersView

🤖 Generated with [Claude Code](https://claude.com/claude-code)