### PR TITLE
feat: 3.5 серверная пагинация в веб-панели

### DIFF
--- a/web/src/api.js
+++ b/web/src/api.js
@@ -76,8 +76,8 @@ export async function getReference() {
 // ---------------------------------------------------------------------------
 
 export async function getOrders(params = {}) {
-  const { data } = await http.get('/orders', { params: { per_page: 1000, ...params } })
-return data.items ?? data
+  const { data } = await http.get('/orders', { params: { per_page: 50, ...params } })
+  return data  // { items, total, page, per_page, total_pages }
 }
 
 export async function getOrder(id) {
@@ -145,9 +145,9 @@ export async function deleteOrderItem(orderId, itemId) {
 // Clients
 // ---------------------------------------------------------------------------
 
-export async function getClients() {
-  const { data } = await http.get('/clients', { params: { per_page: 1000 } })
-  return data.items ?? data
+export async function getClients(params = {}) {
+  const { data } = await http.get('/clients', { params: { per_page: 50, ...params } })
+  return data  // { items, total, page, per_page, total_pages }
 }
 
 export async function getClient(id) {
@@ -159,11 +159,11 @@ export async function getClient(id) {
 // Products
 // ---------------------------------------------------------------------------
 
-export async function getProducts(inStockOnly = false) {
+export async function getProducts(inStockOnly = false, params = {}) {
   const { data } = await http.get('/products', {
-    params: { per_page: 1000, ...(inStockOnly ? { in_stock_only: true } : {}) }
+    params: { per_page: 100, ...(inStockOnly ? { in_stock_only: true } : {}), ...params }
   })
-return data.items ?? data
+  return data  // { items, total, page, per_page, total_pages }
 }
 
 export async function createProduct(body) {

--- a/web/src/views/ClientsView.vue
+++ b/web/src/views/ClientsView.vue
@@ -6,18 +6,18 @@
       <DataTable
         :value="clients"
         :loading="loading"
+        lazy
         paginator
-        :rows="25"
+        :rows="50"
+        :total-records="totalRecords"
         row-hover
-        filter-display="row"
-        :global-filter-fields="['name', 'phone', 'city']"
-        v-model:filters="filters"
         class="text-sm"
+        @page="onPage"
         @row-click="(e) => $router.push(`/clients/${e.data.id}`)"
       >
         <template #header>
           <div class="flex justify-between items-center p-1">
-            <span class="text-base font-semibold text-gray-700">{{ clients.length }} клиентов</span>
+            <span class="text-base font-semibold text-gray-700">{{ totalRecords }} клиентов</span>
             <div class="flex gap-2 items-center">
               <IconField>
                 <InputIcon class="pi pi-search" />
@@ -67,7 +67,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import DataTable from 'primevue/datatable'
 import Column from 'primevue/column'
 import InputText from 'primevue/inputtext'
@@ -78,28 +78,37 @@ import { getClients, exportClients } from '../api.js'
 
 const loading = ref(true)
 const exporting = ref(false)
-const allClients = ref([])
+const clients = ref([])
+const totalRecords = ref(0)
+const currentPage = ref(1)
 const searchQuery = ref('')
-const filters = ref({})
 
-const clients = computed(() => {
-  const q = searchQuery.value.toLowerCase()
-  if (!q) return allClients.value
-  return allClients.value.filter(
-    (c) =>
-      c.name?.toLowerCase().includes(q) ||
-      c.phone?.includes(q) ||
-      c.city?.toLowerCase().includes(q)
-  )
-})
+let searchTimer = null
 
-onMounted(async () => {
+async function loadClients(page = 1) {
+  loading.value = true
+  currentPage.value = page
   try {
-    allClients.value = await getClients()
+    const params = { page }
+    if (searchQuery.value) params.search = searchQuery.value
+    const result = await getClients(params)
+    clients.value = result.items ?? result
+    totalRecords.value = result.total ?? clients.value.length
   } finally {
     loading.value = false
   }
+}
+
+function onPage(event) {
+  loadClients(event.page + 1)
+}
+
+watch(searchQuery, () => {
+  clearTimeout(searchTimer)
+  searchTimer = setTimeout(() => loadClients(1), 400)
 })
+
+onMounted(() => loadClients())
 
 async function doExport() {
   exporting.value = true

--- a/web/src/views/DashboardView.vue
+++ b/web/src/views/DashboardView.vue
@@ -213,12 +213,12 @@ const DELIVERY_COLORS = ['#f59e0b', '#3b82f6', '#10b981', '#8b5cf6', '#ef4444']
 
 onMounted(async () => {
   try {
-    const [dashData, ordersData] = await Promise.all([
+    const [dashData, ordersResult] = await Promise.all([
       getDashboard(),
-      getOrders()
+      getOrders({ per_page: 10 })
     ])
     stats.value = dashData
-    recentOrders.value = ordersData.slice(0, 10)
+    recentOrders.value = ordersResult.items ?? ordersResult
   } finally {
     loading.value = false
     ordersLoading.value = false

--- a/web/src/views/NewOrderView.vue
+++ b/web/src/views/NewOrderView.vue
@@ -157,7 +157,8 @@ const form = ref({
 })
 
 onMounted(async () => {
-  const [prods, refData] = await Promise.all([getProducts(), getReference()])
+  const [prodsResult, refData] = await Promise.all([getProducts(), getReference()])
+  const prods = prodsResult.items ?? prodsResult
   products.value = prods.map((p) => ({ id: p.id, name: p.name, price: p.price }))
   deliveryOptions.value = refData.delivery_methods
 })

--- a/web/src/views/OrdersView.vue
+++ b/web/src/views/OrdersView.vue
@@ -50,10 +50,13 @@
       <DataTable
         :value="orders"
         :loading="loading"
+        lazy
         paginator
-        :rows="20"
+        :rows="50"
+        :total-records="totalRecords"
         row-hover
         class="text-sm"
+        @page="onPage"
         @row-click="(e) => $router.push(`/orders/${e.data.id}`)"
       >
         <template #empty>
@@ -114,6 +117,8 @@ import { formatDate, formatMoney } from '../utils.js'
 const loading = ref(true)
 const exporting = ref(false)
 const orders = ref([])
+const totalRecords = ref(0)
+const currentPage = ref(1)
 const filterStatus = ref('')
 const filterSource = ref('')
 const statusOptions = ref([])
@@ -126,22 +131,29 @@ onMounted(async () => {
   await loadOrders()
 })
 
-async function loadOrders() {
+async function loadOrders(page = 1) {
   loading.value = true
+  currentPage.value = page
   try {
-    const params = {}
+    const params = { page }
     if (filterStatus.value) params.status = filterStatus.value
     if (filterSource.value) params.source = filterSource.value
-    orders.value = await getOrders(params)
+    const result = await getOrders(params)
+    orders.value = result.items ?? result
+    totalRecords.value = result.total ?? orders.value.length
   } finally {
     loading.value = false
   }
 }
 
+function onPage(event) {
+  loadOrders(event.page + 1)
+}
+
 function resetFilters() {
   filterStatus.value = ''
   filterSource.value = ''
-  loadOrders()
+  loadOrders(1)
 }
 
 async function doExport() {

--- a/web/src/views/PackingView.vue
+++ b/web/src/views/PackingView.vue
@@ -196,16 +196,18 @@ async function loadOrders() {
   loading.value = true
   try {
     // Загружаем заказы со статусами "Подтверждён" и "В сборке"
-    const { data: confirmed, offline: off1 } = await fetchWithCache(
+    const { data: confirmedRaw, offline: off1 } = await fetchWithCache(
       'packing-confirmed',
-      () => getOrders({ status: 'Подтверждён' })
+      () => getOrders({ status: 'Подтверждён', per_page: 200 })
     )
-    const { data: assembling, offline: off2 } = await fetchWithCache(
+    const { data: assemblingRaw, offline: off2 } = await fetchWithCache(
       'packing-assembling',
-      () => getOrders({ status: 'В сборке' })
+      () => getOrders({ status: 'В сборке', per_page: 200 })
     )
     offline.value = off1 || off2
 
+    const confirmed = confirmedRaw?.items ?? confirmedRaw
+    const assembling = assemblingRaw?.items ?? assemblingRaw
     const allOrders = [...(assembling || []), ...(confirmed || [])]
 
     // Загрузить позиции для каждого заказа

--- a/web/src/views/ProductsView.vue
+++ b/web/src/views/ProductsView.vue
@@ -190,7 +190,8 @@ async function doExport() {
 async function loadProducts() {
   loading.value = true
   try {
-    products.value = await getProducts(!showAll.value)
+    const result = await getProducts(!showAll.value)
+    products.value = result.items ?? result
   } finally {
     loading.value = false
   }

--- a/web/src/views/StockView.vue
+++ b/web/src/views/StockView.vue
@@ -202,8 +202,9 @@ function onOffline() {
 async function loadProducts() {
   loading.value = true
   try {
-    const { data, offline: off } = await fetchWithCache('stock-products', () => getProducts())
+    const { data: rawData, offline: off } = await fetchWithCache('stock-products', () => getProducts())
     offline.value = off
+    const data = rawData?.items ?? rawData
     products.value = (data || []).map(p => ({
       ...p,
       stock: p.stock ?? null,


### PR DESCRIPTION
## Что сделано

Заменена «фиктивная» пагинация (`per_page=1000`) на настоящую серверную пагинацию.

## Изменения

- **`web/src/api.js`** — `getOrders/getClients/getProducts` возвращают `{items, total, page, per_page, total_pages}` вместо плоского массива
- **`OrdersView.vue`** — DataTable в режиме `lazy`, обработчик `@page`, `loadOrders(page)`
- **`ClientsView.vue`** — lazy DataTable + дебаунс поиска 400ms (server-side `?search=...`)
- **`DashboardView/NewOrderView/StockView/PackingView`** — исправлен разбор ответа через `.items ?? data`

## Связано с

- P2 технический долг: `per_page=1000` → серверная пагинация

🤖 Generated with [Claude Code](https://claude.com/claude-code)