### PR TITLE
feat: ACTIVE_GROUP_IDS — бот отвечает на все сообщения в доверенных группах

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -20,7 +20,7 @@ from aiogram.types import (
 
 import httpx
 
-from src.config import TELEGRAM_BOT_TOKEN, BASE_DIR, PDFS_DIR, BEEKEEPER_CHAT_ID, ADMIN_CHAT_ID, ADMIN_IDS, TG_SOCKS_PROXY, DEVBOT_API_URL
+from src.config import TELEGRAM_BOT_TOKEN, BASE_DIR, PDFS_DIR, BEEKEEPER_CHAT_ID, ADMIN_CHAT_ID, ADMIN_IDS, ACTIVE_GROUP_IDS, TG_SOCKS_PROXY, DEVBOT_API_URL
 from src.phone_utils import validate_phone, format_phone
 from src.delivery.tracker import OrderTracker
 from src.integrations.uds import UDSClient, UDSPoller
@@ -731,6 +731,8 @@ async def cb_ask_about_product(callback: types.CallbackQuery):
 
 def _should_respond(message: types.Message) -> bool:
     if message.chat.type == ChatType.PRIVATE:
+        return True
+    if message.chat.id in ACTIVE_GROUP_IDS:
         return True
     text = message.text or ""
     if f"@{BOT_USERNAME}" in text:

--- a/src/config.py
+++ b/src/config.py
@@ -39,6 +39,13 @@ INTEGRAM_LOGIN = os.getenv("INTEGRAM_LOGIN")
 INTEGRAM_PASSWORD = os.getenv("INTEGRAM_PASSWORD")
 INTEGRAM_DB = os.getenv("INTEGRAM_DB")
 
+# Группы где бот отвечает на все сообщения без @упоминания
+# Несколько ID через запятую: ACTIVE_GROUP_IDS=-100123,-100456
+_groups_raw = os.getenv("ACTIVE_GROUP_IDS", "")
+ACTIVE_GROUP_IDS: frozenset[int] = frozenset(
+    int(x.strip()) for x in _groups_raw.split(",") if x.strip().lstrip("-").isdigit()
+)
+
 # Telegram ID пчеловода для уведомлений о новых заказах
 _beekeeper_raw = os.getenv("BEEKEEPER_CHAT_ID")
 BEEKEEPER_CHAT_ID: int | None = int(_beekeeper_raw) if _beekeeper_raw else None


### PR DESCRIPTION
## Summary
- `config.py`: добавлен `ACTIVE_GROUP_IDS: frozenset[int]` — список групп где бот отвечает без @упоминания
- `bot.py`: `_should_respond()` проверяет `chat.id in ACTIVE_GROUP_IDS`
- Настройка через `.env`: `ACTIVE_GROUP_IDS=-1003862791957`

## Test plan
- [ ] Добавить `ACTIVE_GROUP_IDS=-1003862791957` в `.env` на VPS
- [ ] Перезапустить beebot
- [ ] Написать в группу без @упоминания — бот должен ответить

🤖 Generated with [Claude Code](https://claude.com/claude-code)