### PR TITLE
fix: export default http из api.js — исправить сборку ArchitectureView

### DIFF
--- a/web/src/api.js
+++ b/web/src/api.js
@@ -8,6 +8,8 @@ const http = axios.create({
   timeout: 30000
 })
 
+export default http
+
 // Автоматически добавляем JWT-токен в заголовки
 http.interceptors.request.use((config) => {
   const token = localStorage.getItem('token')


### PR DESCRIPTION
## Summary
- Добавлен `export default http` в `api.js`
- `ArchitectureView.vue` использует `import api from '../api.js'` и вызывает `api.get(...)` — без default export сборка падала

🤖 Generated with [Claude Code](https://claude.com/claude-code)