### PR TITLE
feat: дублировать уведомления пчеловода в групповой чат

### DIFF
--- a/src/agents/logist.py
+++ b/src/agents/logist.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 from aiogram.fsm.state import State, StatesGroup
 
+from src.config import ACTIVE_GROUP_IDS
 from src.crm_schema import DELIVERY_METHODS
 from src.models import Client, Product
 
@@ -421,14 +422,20 @@ class LogistAgent:
         if not self._beekeeper_chat_id:
             logger.info("BEEKEEPER_CHAT_ID не задан — уведомление пропущено.")
             return
+        text = f"🍯 *Новый заказ!*\n\n{order_summary}"
         try:
             await bot.send_message(
                 self._beekeeper_chat_id,
-                f"🍯 *Новый заказ!*\n\n{order_summary}",
+                text,
                 parse_mode="Markdown",
             )
         except Exception as e:
             logger.error("Не удалось уведомить пчеловода: %s", e)
+        for group_id in ACTIVE_GROUP_IDS:
+            try:
+                await bot.send_message(group_id, text, parse_mode="Markdown")
+            except Exception as e:
+                logger.warning("Не удалось отправить уведомление в группу %d: %s", group_id, e)
 
     # ------------------------------------------------------------------
     # Совместимость со старым интерфейсом оркестратора

--- a/src/integrations/uds.py
+++ b/src/integrations/uds.py
@@ -501,6 +501,11 @@ async def _notify_beekeeper(
         await bot.send_message(chat_id, text, parse_mode="Markdown")
     except Exception as e:
         logger.error("UDS: не удалось отправить уведомление пчеловоду: %s", e)
+    for group_id in config.ACTIVE_GROUP_IDS:
+        try:
+            await bot.send_message(group_id, text, parse_mode="Markdown")
+        except Exception as e:
+            logger.warning("UDS: не удалось отправить уведомление в группу %d: %s", group_id, e)
 
 
 # ---------------------------------------------------------------------------

--- a/src/notifications.py
+++ b/src/notifications.py
@@ -23,7 +23,7 @@ from typing import Optional
 from aiogram import Bot
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
-from src.config import BEEKEEPER_CHAT_ID
+from src.config import BEEKEEPER_CHAT_ID, ACTIVE_GROUP_IDS
 
 logger = logging.getLogger(__name__)
 
@@ -198,6 +198,11 @@ class Notifier:
             )
         except Exception as e:
             logger.error("Не удалось отправить уведомление пчеловоду: %s", e)
+        for group_id in ACTIVE_GROUP_IDS:
+            try:
+                await self._bot.send_message(group_id, text, parse_mode="Markdown")
+            except Exception as e:
+                logger.warning("Не удалось отправить уведомление в группу %d: %s", group_id, e)
 
     async def _send_to_client(self, telegram_id: int, text: str) -> None:
         """Отправить уведомление клиенту (если есть Telegram ID)."""


### PR DESCRIPTION
## Summary
- Новые заказы из Telegram и UDS дублируются в группы из `ACTIVE_GROUP_IDS`
- Подтверждения заказов и трекинг тоже дублируются
- Кнопки «Подтвердить/Отклонить» в группу не отправляются (только текст)

🤖 Generated with [Claude Code](https://claude.com/claude-code)