### PR TITLE
feat: приветствие по имени при первом сообщении

### DIFF
--- a/src/agents/beebot.py
+++ b/src/agents/beebot.py
@@ -82,6 +82,7 @@ class BeebotAgent:
         style: str | None = None,
         memory_facts: list[str] | None = None,
         advice_text: str | None = None,
+        user_name: str | None = None,
     ) -> tuple[str, list[dict]]:
         """Ответить на вопрос. Возвращает (ответ, список чанков)."""
         chunks = self.kb.search(query)
@@ -91,5 +92,6 @@ class BeebotAgent:
             style=style,
             memory_facts=memory_facts,
             advice_text=advice_text,
+            user_name=user_name,
         )
         return response, chunks

--- a/src/bot.py
+++ b/src/bot.py
@@ -787,8 +787,9 @@ async def handle_question(message: types.Message, state: FSMContext):
     await bot.send_chat_action(message.chat.id, "typing")
 
     style = _user_styles.get(message.from_user.id)
+    user_name = message.from_user.first_name or None
     try:
-        response, chunks = await orchestrator.route(message.from_user.id, query, style=style)
+        response, chunks = await orchestrator.route(message.from_user.id, query, style=style, user_name=user_name)
         intent = orchestrator.get_intent(message.from_user.id)
         logger.info(f"Intent: {intent}, chunks: {len(chunks)}")
 

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -136,6 +136,7 @@ class LLMClient:
         style: str | None = None,
         memory_facts: list[str] | None = None,
         advice_text: str | None = None,
+        user_name: str | None = None,
     ) -> str:
         """Generate a response for the user's query with context.
 
@@ -152,6 +153,11 @@ class LLMClient:
             system += "\n\nСтиль ответа: " + VOICE_STYLES[style]["prompt_suffix"]
         if advice_text:
             system += "\n\nДополнительные советы пчеловода:\n" + advice_text
+        if user_name:
+            if not history:
+                system += f"\n\nИМЯ ПОЛЬЗОВАТЕЛЯ: {user_name}. Начни с короткого приветствия по имени, затем сразу к делу."
+            else:
+                system += f"\n\nПРОДОЛЖЕНИЕ РАЗГОВОРА с {user_name}. НЕ здоровайся — сразу отвечай по делу."
 
         messages: list[dict] = [{"role": "system", "content": system}]
         if history:

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -80,6 +80,7 @@ class OrchestratorState(TypedDict):
     chunks: list[dict]   # knowledge base chunks (from BEEBOT)
     history: list[dict]  # conversation history for LLM
     style: str | None    # «Голос Улья» — стиль ответа
+    user_name: str | None  # имя пользователя из Telegram
 
 
 # ---------------------------------------------------------------------------
@@ -226,6 +227,7 @@ class Orchestrator:
         user_id: int,
         query: str,
         style: str | None = None,
+        user_name: str | None = None,
     ) -> tuple[str, list[dict]]:
         """Маршрутизировать запрос к нужному агенту.
 
@@ -245,6 +247,7 @@ class Orchestrator:
             "chunks": [],
             "history": history,
             "style": style,
+            "user_name": user_name,
         }
 
         result = await self._graph.ainvoke(initial_state)
@@ -354,6 +357,7 @@ class Orchestrator:
             style=state.get("style"),
             memory_facts=memory_facts or None,
             advice_text=advice_text,
+            user_name=state.get("user_name"),
         )
 
         # Авто-сохранить факт если пользователь упомянул здоровье/интерес


### PR DESCRIPTION
## Summary

- Прокидываем `user_name` (Telegram `first_name`) от `bot.py` → оркестратор → агент → LLM
- Первое сообщение: инструкция в системном промпте «начни с приветствия по имени»
- Продолжение разговора: инструкция «не здоровайся, сразу отвечай»

## Test plan
- [ ] Написать боту впервые — должен ответить «Привет, Алексей!» (не «Привет, друг!»)
- [ ] Второй вопрос подряд — без повторного приветствия

🤖 Generated with [Claude Code](https://claude.com/claude-code)