### PR TITLE
feat(phases11.1+11.3): Worker→client switch + Low stock alert

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -163,7 +163,7 @@ async def main():
 
     # --- Режим работника склада ---
     if integram_client:
-        setup_worker(integram_client, bot)
+        setup_worker(integram_client, bot, gift_broker=gift_broker)
         from src.notifications import Notifier
         import src.notifications as _notif_module
         _notif_module._worker_notifier = Notifier(bot)
@@ -173,7 +173,7 @@ async def main():
     # --- CRM Snapshot ---
     if integram_client:
         from src.crm_snapshot import CrmSnapshot
-        _state._crm_snapshot = CrmSnapshot(integram_client)
+        _state._crm_snapshot = CrmSnapshot(integram_client, alert_fn=_alert)
         asyncio.create_task(_state._crm_snapshot.run())
         logger.info("CRM snapshot запущен (интервал %d сек).", _state._crm_snapshot._refresh_interval)
 

--- a/src/crm_snapshot.py
+++ b/src/crm_snapshot.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from datetime import datetime
-from typing import Optional, TYPE_CHECKING
+from typing import Callable, Awaitable, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from src.integram_client import IntegramClient
@@ -22,6 +23,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 DEFAULT_REFRESH_INTERVAL = 300  # 5 минут
+LOW_STOCK_THRESHOLD = 5          # алерт при остатке < N штук
+_LOW_STOCK_DEBOUNCE = 86400      # не повторять алерт по одному товару чаще 1 раза в сутки
 
 
 class CrmSnapshot:
@@ -34,10 +37,17 @@ class CrmSnapshot:
         order = snapshot.get_order(order_id)  # быстрый поиск
     """
 
-    def __init__(self, crm: "IntegramClient", refresh_interval: int = DEFAULT_REFRESH_INTERVAL):
+    def __init__(
+        self,
+        crm: "IntegramClient",
+        refresh_interval: int = DEFAULT_REFRESH_INTERVAL,
+        alert_fn: "Optional[Callable[[str], Awaitable[None]]]" = None,
+    ):
         self._crm = crm
         self._refresh_interval = refresh_interval
+        self._alert_fn = alert_fn
         self._running = False
+        self._low_stock_alerted: dict[int, float] = {}  # product_id → last alert monotonic
 
         self.orders: list["Order"] = []
         self.clients: list["Client"] = []
@@ -94,6 +104,33 @@ class CrmSnapshot:
             "CRM snapshot: готов — %d заказов, %d позиций, %d клиентов, %d товаров",
             len(self.orders), total_items, len(self.clients), len(self.products),
         )
+
+        # Алерт при низком остатке (11.3)
+        if self._alert_fn and self.products:
+            await self._check_low_stock()
+
+    async def _check_low_stock(self) -> None:
+        """Отправить алерт пчеловоду если остаток товара < LOW_STOCK_THRESHOLD."""
+        now = time.monotonic()
+        for product in self.products:
+            if product.stock is None:
+                continue
+            if product.stock >= LOW_STOCK_THRESHOLD:
+                continue
+            last = self._low_stock_alerted.get(product.id, 0)
+            if now - last < _LOW_STOCK_DEBOUNCE:
+                continue
+            self._low_stock_alerted[product.id] = now
+            try:
+                await self._alert_fn(
+                    f"⚠️ *Низкий остаток*: {product.name} — *{product.stock} шт.*"
+                )
+                logger.info(
+                    "CrmSnapshot: алерт низкого остатка — %s (%d шт.)",
+                    product.name, product.stock,
+                )
+            except Exception as _e:
+                logger.warning("CrmSnapshot: ошибка алерта низкого остатка: %s", _e)
 
     def stop(self) -> None:
         """Остановить фоновую задачу."""

--- a/src/gift_protocol.py
+++ b/src/gift_protocol.py
@@ -153,6 +153,32 @@ class GiftBroker:
         """Делегировать get_intent в оркестратор."""
         return self._orchestrator.get_intent(user_id)
 
+    def suggest_interface(
+        self,
+        user_id: int,
+        is_worker: bool = False,
+    ) -> str:
+        """Context-aware выбор интерфейса для /start.
+
+        Проверяет SharedContext: если работник явно переключился в режим
+        покупателя (interface_mode="client"), возвращает "client".
+
+        Returns:
+            "worker" | "client"
+        """
+        if not is_worker:
+            return "client"
+        ctx = self._ctx.get(user_id)
+        if ctx.interface_mode == "client":
+            return "client"
+        return "worker"
+
+    def set_interface_mode(self, user_id: int, mode: str) -> None:
+        """Установить режим интерфейса пользователя ("default" | "client")."""
+        ctx = self._ctx.get(user_id)
+        ctx.interface_mode = mode
+        ctx.touch()
+
     async def defer(self, user_id: int, reason: str) -> None:
         """Отложить Gift (агент занят или данные временно недоступны)."""
         logger.info("Gift DEFERRED: user=%d reason=%s", user_id, reason)

--- a/src/routers/user.py
+++ b/src/routers/user.py
@@ -77,8 +77,18 @@ async def cmd_start(message: types.Message):
     is_admin = _is_admin(uid)
 
     if WORKER_CHAT_IDS and uid in WORKER_CHAT_IDS and not is_admin:
-        await _worker_show_queue(message.chat.id, message)
-        return
+        # GiftBroker выбирает интерфейс по контексту (11.1):
+        # если работник ранее переключился в режим покупателя — показать клиентский UI
+        interface = (
+            _gift_broker.suggest_interface(uid, is_worker=True)
+            if _gift_broker else "worker"
+        )
+        if interface == "worker":
+            await _worker_show_queue(message.chat.id, message)
+            return
+        # interface == "client" — сбросить режим и показать клиентский /start
+        if _gift_broker:
+            _gift_broker.set_interface_mode(uid, "default")
 
     if is_admin:
         _admin_view_mode[uid] = "admin"

--- a/src/routers/worker.py
+++ b/src/routers/worker.py
@@ -9,18 +9,21 @@ from src.config import WORKER_CHAT_IDS, ADMIN_IDS
 from src.integram_client import IntegramClient
 from src.agents import worker as worker_agent
 from src.agents.worker import worker_state
+from src.gift_protocol import GiftBroker
 
 logger = logging.getLogger(__name__)
 router = Router()
 
 _worker_crm: Optional[IntegramClient] = None
 _bot: Optional[Bot] = None
+_gift_broker: Optional[GiftBroker] = None
 
 
-def setup_worker(crm: IntegramClient, bot: Bot) -> None:
-    global _worker_crm, _bot
+def setup_worker(crm: IntegramClient, bot: Bot, gift_broker: Optional[GiftBroker] = None) -> None:
+    global _worker_crm, _bot, _gift_broker
     _worker_crm = crm
     _bot = bot
+    _gift_broker = gift_broker
 
 
 def _is_worker(user_id: int) -> bool:
@@ -167,3 +170,40 @@ async def cb_worker_done(callback: types.CallbackQuery):
         return
 
     await _worker_show_queue(callback.message.chat.id, callback)
+
+    # Если очередь пуста — предложить переключиться в режим покупателя (11.1)
+    if _worker_crm:
+        try:
+            remaining = await worker_agent.get_worker_queue(_worker_crm)
+            if not remaining:
+                from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+                kb = InlineKeyboardMarkup(inline_keyboard=[[
+                    InlineKeyboardButton(
+                        text="🛒 Перейти в режим покупателя",
+                        callback_data="worker:client_mode",
+                    )
+                ]])
+                await _bot.send_message(
+                    callback.message.chat.id,
+                    "🎉 Все заказы собраны! Хотите перейти в режим покупателя?",
+                    reply_markup=kb,
+                )
+        except Exception as _e:
+            logger.debug("cb_worker_done: ошибка проверки очереди после завершения: %s", _e)
+
+
+@router.callback_query(F.data == "worker:client_mode")
+async def cb_worker_client_mode(callback: types.CallbackQuery):
+    """Работник переключается в режим покупателя."""
+    await callback.answer()
+    uid = callback.from_user.id
+
+    # Сохранить режим в SharedContext через GiftBroker (11.1)
+    if _gift_broker:
+        _gift_broker.set_interface_mode(uid, "client")
+
+    from src.routers.keyboards import WELCOME_MESSAGE, build_main_keyboard
+    await callback.message.answer(
+        WELCOME_MESSAGE,
+        reply_markup=build_main_keyboard(is_admin=False, view="user"),
+    )

--- a/src/shared_context.py
+++ b/src/shared_context.py
@@ -29,6 +29,7 @@ class UserContext:
     interests: list[str] = field(default_factory=list)          # упомянутые продукты
     last_products_hint: list[str] = field(default_factory=list) # из онтологии
     checklist: dict = field(default_factory=dict)               # {order_id: set[item_id]} для WorkerAgent
+    interface_mode: str = "default"                             # "default" | "client" — выбор интерфейса /start
     updated_at: float = field(default_factory=time.monotonic)
 
     def is_fresh(self, ttl: float = _DIALOG_TTL) -> bool:

--- a/tests/test_crm_snapshot_low_stock.py
+++ b/tests/test_crm_snapshot_low_stock.py
@@ -1,0 +1,175 @@
+"""Tests for CrmSnapshot low stock alert — Phase 11.3."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.crm_snapshot import CrmSnapshot, LOW_STOCK_THRESHOLD, _LOW_STOCK_DEBOUNCE
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_product(product_id: int, name: str, stock: int):
+    p = MagicMock()
+    p.id = product_id
+    p.name = name
+    p.stock = stock
+    return p
+
+
+def _make_snapshot(alert_fn=None) -> CrmSnapshot:
+    crm = MagicMock()
+    return CrmSnapshot(crm, alert_fn=alert_fn)
+
+
+# ---------------------------------------------------------------------------
+# _check_low_stock
+# ---------------------------------------------------------------------------
+
+class TestLowStockAlert:
+    @pytest.mark.asyncio
+    async def test_alert_when_stock_below_threshold(self):
+        alert_fn = AsyncMock()
+        snap = _make_snapshot(alert_fn=alert_fn)
+        snap.products = [_make_product(1, "Прополис", LOW_STOCK_THRESHOLD - 1)]
+
+        await snap._check_low_stock()
+
+        alert_fn.assert_called_once()
+        msg = alert_fn.call_args[0][0]
+        assert "Прополис" in msg
+        assert str(LOW_STOCK_THRESHOLD - 1) in msg
+
+    @pytest.mark.asyncio
+    async def test_no_alert_when_stock_at_threshold(self):
+        alert_fn = AsyncMock()
+        snap = _make_snapshot(alert_fn=alert_fn)
+        snap.products = [_make_product(1, "Мёд", LOW_STOCK_THRESHOLD)]
+
+        await snap._check_low_stock()
+
+        alert_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_alert_when_stock_above_threshold(self):
+        alert_fn = AsyncMock()
+        snap = _make_snapshot(alert_fn=alert_fn)
+        snap.products = [_make_product(1, "Перга", LOW_STOCK_THRESHOLD + 10)]
+
+        await snap._check_low_stock()
+
+        alert_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_alert_when_stock_is_none(self):
+        alert_fn = AsyncMock()
+        snap = _make_snapshot(alert_fn=alert_fn)
+        p = _make_product(1, "Гомогенат", 0)
+        p.stock = None  # unknown stock
+        snap.products = [p]
+
+        await snap._check_low_stock()
+
+        alert_fn.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_debounce_prevents_repeated_alerts(self):
+        """Same product should not be alerted twice within debounce window."""
+        alert_fn = AsyncMock()
+        snap = _make_snapshot(alert_fn=alert_fn)
+        snap.products = [_make_product(1, "Прополис", 2)]
+
+        await snap._check_low_stock()
+        await snap._check_low_stock()  # second call within debounce
+
+        assert alert_fn.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_alert_after_debounce_period_expires(self):
+        """Alert should fire again after debounce period."""
+        alert_fn = AsyncMock()
+        snap = _make_snapshot(alert_fn=alert_fn)
+        snap.products = [_make_product(1, "Прополис", 2)]
+
+        # Simulate first alert happened > debounce ago
+        snap._low_stock_alerted[1] = time.monotonic() - (_LOW_STOCK_DEBOUNCE + 1)
+
+        await snap._check_low_stock()
+
+        alert_fn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_alerts_multiple_low_stock_products(self):
+        """Multiple low stock products should each get their own alert."""
+        alert_fn = AsyncMock()
+        snap = _make_snapshot(alert_fn=alert_fn)
+        snap.products = [
+            _make_product(1, "Прополис", 1),
+            _make_product(2, "Перга", 3),
+            _make_product(3, "Мёд", 50),   # not low
+        ]
+
+        await snap._check_low_stock()
+
+        assert alert_fn.call_count == 2
+        calls_text = " ".join(str(c) for c in alert_fn.call_args_list)
+        assert "Прополис" in calls_text
+        assert "Перга" in calls_text
+        assert "Мёд" not in calls_text
+
+    @pytest.mark.asyncio
+    async def test_no_alert_when_alert_fn_is_none(self):
+        """Snapshot without alert_fn should never call anything."""
+        snap = _make_snapshot(alert_fn=None)
+        snap.products = [_make_product(1, "Прополис", 1)]
+        # Should not raise even without alert_fn
+        # _check_low_stock only called when alert_fn is set (guard in refresh)
+        # but calling directly should be safe too
+        await snap._check_low_stock()  # no exception expected
+
+    @pytest.mark.asyncio
+    async def test_alert_error_does_not_propagate(self):
+        """If alert_fn raises, _check_low_stock should swallow the error."""
+        alert_fn = AsyncMock(side_effect=Exception("Telegram down"))
+        snap = _make_snapshot(alert_fn=alert_fn)
+        snap.products = [_make_product(1, "Прополис", 1)]
+
+        # Should not raise
+        await snap._check_low_stock()
+
+    @pytest.mark.asyncio
+    async def test_alert_includes_product_name_and_stock(self):
+        alert_fn = AsyncMock()
+        snap = _make_snapshot(alert_fn=alert_fn)
+        snap.products = [_make_product(42, "ПЖВМ", 0)]
+
+        await snap._check_low_stock()
+
+        msg = alert_fn.call_args[0][0]
+        assert "ПЖВМ" in msg
+        assert "0" in msg
+
+
+# ---------------------------------------------------------------------------
+# CrmSnapshot constructor
+# ---------------------------------------------------------------------------
+
+class TestCrmSnapshotInit:
+    def test_default_has_no_alert_fn(self):
+        crm = MagicMock()
+        snap = CrmSnapshot(crm)
+        assert snap._alert_fn is None
+
+    def test_custom_alert_fn_stored(self):
+        crm = MagicMock()
+        fn = AsyncMock()
+        snap = CrmSnapshot(crm, alert_fn=fn)
+        assert snap._alert_fn is fn
+
+    def test_low_stock_alerted_starts_empty(self):
+        crm = MagicMock()
+        snap = CrmSnapshot(crm)
+        assert snap._low_stock_alerted == {}

--- a/tests/test_gift_protocol_interface.py
+++ b/tests/test_gift_protocol_interface.py
@@ -1,0 +1,89 @@
+"""Tests for GiftBroker.suggest_interface() and set_interface_mode() — Phase 11.1."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.gift_protocol import GiftBroker
+from src.shared_context import SharedContextStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_broker() -> GiftBroker:
+    ctx_store = SharedContextStore()
+    with (
+        patch("src.orchestrator.Groq"),
+        patch("src.orchestrator.BeebotAgent"),
+        patch("src.orchestrator.LogistAgent"),
+        patch("src.orchestrator.AnalystAgent"),
+    ):
+        from src.orchestrator import Orchestrator
+        orch = Orchestrator()
+    broker = GiftBroker(
+        orchestrator=orch,
+        context_store=ctx_store,
+        anamnesis=MagicMock(),
+        crm_agent=None,
+    )
+    return broker
+
+
+# ---------------------------------------------------------------------------
+# suggest_interface
+# ---------------------------------------------------------------------------
+
+class TestSuggestInterface:
+    def test_non_worker_always_gets_client(self):
+        broker = _make_broker()
+        assert broker.suggest_interface(1001, is_worker=False) == "client"
+
+    def test_worker_with_default_mode_gets_worker(self):
+        broker = _make_broker()
+        assert broker.suggest_interface(1002, is_worker=True) == "worker"
+
+    def test_worker_who_switched_to_client_gets_client(self):
+        broker = _make_broker()
+        broker.set_interface_mode(1003, "client")
+        assert broker.suggest_interface(1003, is_worker=True) == "client"
+
+    def test_worker_after_reset_gets_worker(self):
+        broker = _make_broker()
+        broker.set_interface_mode(1004, "client")
+        broker.set_interface_mode(1004, "default")
+        assert broker.suggest_interface(1004, is_worker=True) == "worker"
+
+    def test_unknown_user_worker_gets_worker_by_default(self):
+        """User who has never interacted defaults to worker interface."""
+        broker = _make_broker()
+        assert broker.suggest_interface(9999, is_worker=True) == "worker"
+
+
+# ---------------------------------------------------------------------------
+# set_interface_mode
+# ---------------------------------------------------------------------------
+
+class TestSetInterfaceMode:
+    def test_set_client_mode_stored_in_context(self):
+        broker = _make_broker()
+        broker.set_interface_mode(2001, "client")
+        ctx = broker._ctx.get(2001)
+        assert ctx.interface_mode == "client"
+
+    def test_set_default_mode_resets_context(self):
+        broker = _make_broker()
+        broker.set_interface_mode(2002, "client")
+        broker.set_interface_mode(2002, "default")
+        ctx = broker._ctx.get(2002)
+        assert ctx.interface_mode == "default"
+
+    def test_mode_change_touches_context(self):
+        """set_interface_mode should update updated_at."""
+        import time
+        broker = _make_broker()
+        before = time.monotonic()
+        broker.set_interface_mode(2003, "client")
+        ctx = broker._ctx.get(2003)
+        assert ctx.updated_at >= before


### PR DESCRIPTION
## Summary

**11.1 — Событийные интерфейсы (context-aware `/start`):**
- `UserContext.interface_mode` — персистентный выбор интерфейса в SharedContext
- `GiftBroker.suggest_interface()` — определяет UI по контексту, не по enum-роли
- После завершения последнего заказа работник видит кнопку «Перейти в режим покупателя»
- `cb_worker_client_mode`: сохраняет mode, показывает клиентский `/start`

**11.3 — Алерт при низком остатке:**
- `CrmSnapshot._check_low_stock()`: при каждом 5-минутном refresh проверяет `stock < 5`
- Дебаунс 24ч на товар — не спамит пчеловоду
- `bot.py`: передаёт `alert_fn=_alert` в `CrmSnapshot`

## Test plan

- [x] `pytest tests/test_gift_protocol_interface.py` — 8 тестов, pass
- [x] `pytest tests/test_crm_snapshot_low_stock.py` — 13 тестов, pass
- [x] Полный suite: 365 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)