### PR TITLE
feat(docs): PDF↔DOCX цикл редактирования инструкций

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR /app
 # System dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    libreoffice-writer \
     && rm -rf /var/lib/apt/lists/*
 
 # Limit thread memory (critical for 2 GB VPS)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       - ./data/processed:/app/data/processed
       - ./data/subtitles:/app/data/subtitles
       - ./data/texts:/app/data/texts
+      - ./data/pdfs:/app/data/pdfs
+      - ./data/docs_word:/app/data/docs_word
     logging:
       driver: json-file
       options:

--- a/docs/team_infra_plan.md
+++ b/docs/team_infra_plan.md
@@ -1,9 +1,31 @@
 # Team Infrastructure — План реализации
 
-> **Дата:** 6 апреля 2026
+> **Дата:** 7 апреля 2026
 > **Статус:** Утверждён Андреем Гавриловым
 > **Цель:** универсальная команда агентов-разработчиков с общей памятью,
 >            переиспользуемая между проектами (BEEBOT, AnalizShum, DahuaAudio и др.)
+
+---
+
+## Философия: Команда = Завод на онтологии дара
+
+*Источник: PLM-GIFT (unidel2035/plm, Гаврилов Денис, март 2026)*
+
+```
+Традиционная команда:  функции → результат
+Команда на дар-онтологии: лица с призванием → дары → воплощение телоса
+```
+
+**Три аксиомы команды:**
+
+1. **Роль — лицо, не функция.** Scout не "собирает данные" — Scout **дарит карту** Architect-у.
+   Каждая роль имеет логос (природу/призвание) и несёт ответственность за качество своего дара.
+
+2. **Агент — слуга, не господин.** Агент анализирует, предлагает, предупреждает.
+   Финальное решение — всегда за Андреем (`human_decision_required: True`).
+
+3. **Память — анамнезис, не архив.** Завершённая задача (✅) не закрыта — она
+   **со-присутствует** в следующей через TeamMemory. Опыт не теряется.
 
 ---
 
@@ -13,145 +35,202 @@
 [хороший инструмент] → [продукт]
 
 Сейчас:    один Claude меняет шляпы → продукт (амнезия между сессиями)
-Цель:      команда агентов с памятью → продукт (накопление опыта)
+Цель:      команда лиц с памятью → продукт (накопление опыта)
 ```
 
-Каждый проект подключает `team-infra` как зависимость.
-Команда помнит паттерны, решения, антипаттерны — между сессиями и между проектами.
-Andрей видит всё через Integram — память команды прозрачна.
+**Жизненный цикл задачи (через GIFT):**
+
+```
+ТЕЛОС (Андрей ставит задачу: что меняется для пользователя)
+  ↓
+[Идея] → [Scout] → [Architect] → [Dev] → [QA+Security] → [DevOps] → [TechWriter] → ✅
+  ↑_________________________АНАМНЕЗИС___________________________________↑
+  Каждый шаг помнит предыдущий. ✅ — не смерть задачи, а передача опыта в TeamMemory.
+```
+
+**Иерархия телоса (приоритет при конфликте):**
+```
+Телос задачи (польза для пользователя)
+  > Security (нет уязвимостей)
+    > QA (тесты зелёные)
+      > простота кода
+        > скорость реализации
+```
 
 ---
 
 ## Архитектура
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                  TEAM LAYER (переиспользуемый)              │
-│                                                             │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────────┐  │
-│  │  Team Memory  │  │  AgentBus    │  │  Role Registry   │  │
-│  │  (Integram    │  │  (file-based │  │  (YAML prompts)  │  │
-│  │   devteam)    │  │  + log)      │  │                  │  │
-│  └──────┬───────┘  └──────┬───────┘  └────────┬─────────┘  │
-│         └─────────────────┼────────────────────┘            │
-│                    ┌──────▼──────┐                          │
-│                    │  AgentCore  │  ← единая точка входа    │
-│                    └──────┬──────┘                          │
-└───────────────────────────┼─────────────────────────────────┘
-                            │ инициализируется с
-┌───────────────────────────▼─────────────────────────────────┐
-│                  PROJECT LAYER (специфичный)                 │
-│                                                             │
-│  ┌─────────────────┐  ┌──────────────────────────────────┐  │
-│  │  context.yaml   │  │  Project Memory                  │  │
-│  │  (стек, ADR,    │  │  (ADR, антипаттерны, state)      │  │
-│  │   fragile zones)│  │  → Integram devteam              │  │
-│  └─────────────────┘  └──────────────────────────────────┘  │
-│                                                             │
-│  BEEBOT / AnalizShum / DahuaAudio / следующий проект...    │
-└─────────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────┐
+│                    ТЕЛОС                                        │
+│          «Что меняется для пользователя»                        │
+│                (задаёт Андрей)                                  │
+└──────────────────────┬──────────────────────────────────────────┘
+                       │ направляет
+┌──────────────────────▼──────────────────────────────────────────┐
+│                  TEAM LAYER (переиспользуемый)                  │
+│                                                                 │
+│  ┌─────────────┐  ┌─────────────┐  ┌───────────────────────┐   │
+│  │ Team Memory  │  │  AgentBus   │  │    Role Registry      │   │
+│  │ (Integram   │  │ (file-based │  │  (лица с призванием)  │   │
+│  │  devteam)   │  │  + log)     │  │                       │   │
+│  └──────┬──────┘  └──────┬──────┘  └──────────┬────────────┘   │
+│         └────────────────┼─────────────────────┘               │
+│                   ┌──────▼──────┐                               │
+│                   │  AgentCore  │  ← единая точка входа         │
+│                   │  + GiftBus  │  ← дары между ролями          │
+│                   └──────┬──────┘                               │
+└──────────────────────────┼──────────────────────────────────────┘
+                           │
+┌──────────────────────────▼──────────────────────────────────────┐
+│               CODE MEMORY GRAPH (Integram devteam)              │
+│                                                                 │
+│  PATTERNS · ANTIPATTERNS · DECISIONS(ADR) · LESSONS            │
+│  + граф связей: задача → паттерн → файл → решение              │
+│  Анамнезис: каждое решение со-присутствует в следующем         │
+└──────────────────────────┬──────────────────────────────────────┘
+                           │ инициализируется с
+┌──────────────────────────▼──────────────────────────────────────┐
+│                  PROJECT LAYER (специфичный)                    │
+│                                                                 │
+│  ┌──────────────────┐  ┌────────────────────────────────────┐   │
+│  │  context.yaml    │  │  Project Memory                    │   │
+│  │  (стек, ADR,     │  │  (ADR, антипаттерны, lifecycle)    │   │
+│  │  fragile zones,  │  │  → Integram devteam                │   │
+│  │  telos)          │  │                                    │   │
+│  └──────────────────┘  └────────────────────────────────────┘   │
+│                                                                 │
+│  BEEBOT / AnalizShum / DahuaAudio / следующий проект...        │
+└─────────────────────────────────────────────────────────────────┘
 ```
 
-### Пайплайн выполнения задачи
+### CRM как PLM-модуль
+
+CRM — не внешняя система. CRM — **модуль PLM фазы эксплуатации**, владелец жизненного цикла отношений с клиентом:
+
+```
+PLM-объект        → CRM-аналог (BEEBOT)
+─────────────────────────────────────────────
+Деталь (лицо)     → Клиент (лицо с историей)
+ECR (рана)        → Обращение / жалоба клиента
+ECO (исцеление)   → Решение проблемы клиента
+BOM (икономия)    → Каталог продуктов + состав заказа
+Released          → Заказ выполнен, доставлен
+Obsolete          → Клиент неактивен (живёт в анамнезисе)
+Анамнезис         → История всех взаимодействий с клиентом
+```
+
+CrmAgent — единственный владелец CRM-данных. Слуга, не господин.
+
+### Пайплайн выполнения задачи (Gift-протокол)
 
 ```
 Андрей
-  │ "разработайте X"
+  │ дарит телос: "задача X, цель Y для пользователя"
   ▼
-Координатор (главный Claude)
-  │ читает context.yaml
-  │ инициализирует AgentBus
+Координатор
+  │ читает context.yaml + TeamMemory
+  │ инициализирует GiftBus (task_id, telos)
   │
-  ├──[Agent: Scout]─────────────────────────────┐
-  │    читает TeamMemory(devteam)                │ параллельно
-  │    исследует кодовую базу                   │
-  │    → ScoutReport → bus/inbox/architect      │
-  │                                             │
-  ├──[Agent: Architect A]───────────────────────┤
-  │    вариант 1                                │ параллельно
-  ├──[Agent: Architect B]───────────────────────┤
-  │    вариант 2                                │
-  │                                             │
-  ├──[Agent: Security]──────────────────────────┘
-  │    оценивает оба варианта
+  ├──[Scout] ──────────────────────────────────┐
+  │   дарит: ScoutGift{карта кода, риски}      │ параллельно
+  ├──[KnowledgeAgent] ─────────────────────────┤
+  │   дарит: AnamnesisGift{похожие решения}    │
+  │                                            │
+  ├──[Architect A] ─────────────────────────── ┤
+  │   получает Scout+Anamnesis                 │ параллельно
+  ├──[Architect B] ─────────────────────────── ┤
+  │   разные подходы                           │
+  │                                            │
+  ├──[Security] ───────────────────────────────┘
+  │   challenge: атакует оба варианта
+  │   (вес: 1.3× — блокирующая роль)
   │
-  Координатор синтезирует консенсус
-  │ пишет DECISIONS в Integram(devteam)
-  │ обновляет context.yaml
+  Координатор синтезирует ConsensusGift
+  │ human_decision_required: True
   ▼
-Андрей: два варианта + рекомендация + риски
-  │ одобряет
+Андрей: варианты + рекомендация + риски
+  │ принимает / отклоняет (акт свободы)
   ▼
 [Backend Dev] + [Frontend Dev] (параллельно)
   │ каждый читает TeamMemory перед работой
-  │ пишет в AgentBus по завершении
+  │ дарит код + тесты
   ▼
-QA → Security → DevOps → Tech Writer
-  │ каждый логирует в Integram
-  ▼
-LESSON записан в TeamMemory(devteam)
-  → доступен в следующей сессии и следующем проекте
+[QA] вес 1.2× → [Security] вес 1.3× → [DevOps] → [TechWriter]
+  │
+LESSON записан в TeamMemory → со-присутствует в следующей задаче
 ```
 
 ---
 
 ## Подсистемы
 
-### 1. Team Memory (Integram, воркспейс `devteam`)
+### 1. Team Memory = Code Memory Graph (Integram devteam)
 
 **Таблицы:**
 
-| Таблица | Назначение | Ключевые поля |
-|---------|-----------|---------------|
-| `PATTERNS` | Паттерны которые работают | name, context, solution, when_to_use, project_examples |
-| `ANTIPATTERNS` | Что нельзя делать и почему | name, what_not_to_do, why, incident, projects_affected |
-| `DECISIONS` | Архитектурные решения (ADR) | project, decision, rationale, alternatives, status, date |
-| `LESSONS` | Уроки из инцидентов | project, what_happened, root_cause, fix, prevention |
-| `AGENT_BUS_LOG` | История передачи эстафеты | session_id, from_role, to_role, task_id, payload, ts |
+| Таблица | GIFT-аналог | Назначение |
+|---------|------------|-----------|
+| `PATTERNS` | Логос | Паттерны с природой и призванием |
+| `ANTIPATTERNS` | Рана | Что нельзя делать — с историей инцидента |
+| `DECISIONS` | Дар инженера | ADR с анамнезисом всей цепочки |
+| `LESSONS` | Обратная связь из эксплуатации | Самый ценный дар |
+| `AGENT_BUS_LOG` | Свидетельство | История всех даров между ролями |
+| `TASK_LIFECYCLE` | Жизненный цикл | Каждая задача с тропосом (статусом) |
 
-**Почему Integram:**
-- REST API из любого агента
-- Семантический поиск (`semantic_search`)
-- Ref-колонки — связи между записями
-- Уже используется в проекте (`integram_api.py`)
-- Ты видишь всё через веб-интерфейс — память прозрачна
-- Разные воркспейсы: `bibot` (CRM бота) vs `devteam` (память команды)
-
-### 2. AgentBus (файловая шина + лог в Integram)
-
+**Граф анамнезиса (Neo4j через Integram):**
 ```
-.agent_bus/              ← в .gitignore
-  inbox/
-    scout.json           ← задание для Scout
-    architect.json       ← ScoutReport для Architect
-  outbox/
-    scout_to_architect.json
-  consensus/
-    task_M6.json         ← результат совещания по задаче M.6
+(задача:M5) -[ПОРОДИЛА]→ (паттерн:AgentContext)
+(задача:M6) -[ИСПОЛЬЗУЕТ]→ (паттерн:AgentContext)
+(задача:M6) -[ПОМНИТ]→ (задача:M5)
+(паттерн:AgentContext) -[В_ФАЙЛЕ]→ (файл:memory_service.py)
 ```
 
-Формат сообщения:
-```json
-{
-  "task_id": "M.6",
-  "from": "scout",
-  "to": "architect",
-  "timestamp": "2026-04-06T10:00:00",
-  "payload": {
-    "files_analyzed": ["src/memory_service.py"],
-    "patterns_found": ["service layer"],
-    "risks": ["N+1 при sync"],
-    "open_questions": ["частота синхронизации?"]
-  }
+### 2. GiftBus (расширение AgentBus)
+
+Каждое сообщение — **дар** со структурой PLM-GIFT:
+
+```python
+@dataclass
+class Gift:
+    giver: str           # роль-отправитель ("scout")
+    receiver: str        # роль-получатель ("architect")
+    content: Any         # содержание дара (ScoutReport, Plan, ...)
+    telos: str           # зачем этот дар (связь с телосом задачи)
+    anamnesis: list[str] # что помним из прошлого (task_ids, gift_ids)
+    freedom: str         # ACCEPTED | DEFERRED | DECLINED
+    cost: int            # кеносис — сколько стоил дар (токены, время)
+    task_id: str
+    timestamp: str
+```
+
+**A5 (Свобода):** получатель может ответить `DEFERRED` — дар откладывается, не теряется. Coordinator ждёт или запрашивает другой дар.
+
+### 3. Role Weights (взвешенный консенсус, из TRADERAGENT)
+
+```python
+ROLE_WEIGHTS = {
+    "security":    1.3,  # блокирующая роль — P0 стопит деплой
+    "qa":          1.2,  # зелёные тесты обязательны
+    "architect":   1.0,  # базовый уровень
+    "backend_dev": 1.0,
+    "frontend_dev": 1.0,
+    "scout":       0.9,  # информирует, не решает
+    "tech_writer": 0.7,  # влияет на качество, не блокирует
 }
 ```
 
-### 3. Project Context (context.yaml)
+### 4. Project Context (context.yaml — расширенный)
 
 ```yaml
 # docs/memory/context.yaml
 project: BEEBOT
-version: "2026-04-06"
+version: "2026-04-07"
+
+# PLM-GIFT поля
+telos: "Цифровой помощник пчеловода — отвечает на вопросы, принимает заказы"
+lifecycle_stage: "In Change"  # In Design | Released | In Change | Obsolete
 
 stack:
   backend: [python3.12, aiogram3, langgraph, fastapi, sqlite]
@@ -160,83 +239,58 @@ stack:
 
 fragile_zones:
   - file: src/bot.py
-    reason: "1899 строк монолит — Scout обязателен перед касанием"
+    reason: "1899 строк монолит — Scout обязателен"
+    telos_risk: "HIGH"  # риск для телоса при неосторожном изменении
   - file: src/crm_constants.py
-    reason: "единый источник всех CRM ID — изменение ломает всё"
+    reason: "единый источник всех CRM ID"
+    telos_risk: "CRITICAL"
 
 current_state:
-  broken: ["ImportError в startup.py (Fix-1)"]
-  in_progress: ["M.5 AgentContext (feat/m5-agent-context)"]
-  blocked: ["Fix-2 A.7 ждёт Fix-1"]
+  tропос: "In Change"  # текущий образ бытия проекта
+  broken: ["ImportError startup.py (Fix-1)"]
+  in_progress: ["M.5 AgentContext"]
+  blocked: ["Fix-2 ждёт Fix-1"]
 
-decisions:
+decisions:  # анамнезис принятых решений
   - id: ADR-001
-    summary: "Squash merge всегда, git reset --hard на VPS (не pull)"
+    summary: "Squash merge + git reset --hard на VPS"
+    anamnesis: []
   - id: ADR-002
-    summary: "INTEGRAM_V2 за feature flag — переключение без деплоя"
-  - id: ADR-003
-    summary: "network_mode: host в Docker — tunnels работают"
+    summary: "INTEGRAM_V2 за feature flag"
+    anamnesis: ["ADR-001"]
 
 team_memory_workspace: "devteam"
 agent_bus_dir: ".agent_bus/"
-```
-
-### 4. Role Registry (машинно-читаемые промты)
-
-```yaml
-# docs/agents/scout.yaml
-role: scout
-description: "Исследует кодовую базу перед любым изменением"
-reads_from: ["context.yaml", "team_memory.PATTERNS", "team_memory.ANTIPATTERNS"]
-writes_to: ["agent_bus.outbox/scout_to_architect.json"]
-tools: [Glob, Grep, Read]  # только чтение, никаких изменений
-output_schema:
-  files_analyzed: list[str]
-  patterns_found: list[str]
-  risks: list[str]
-  fragile_zones_touched: list[str]
-  recommendation: str
 ```
 
 ---
 
 ## Репозиторий
 
-**Отдельный репозиторий:** `gaveron18/team-infra`
+**Отдельный:** `gaveron18/team-infra`
 
 ```
 team-infra/
 ├── team_infra/
-│   ├── __init__.py
-│   ├── team_memory.py      # Integram-клиент для командной памяти
+│   ├── gift.py             # Gift dataclass + GiftBus
+│   ├── team_memory.py      # Integram devteam клиент
 │   ├── agent_bus.py        # файловая шина + лог
 │   ├── project_context.py  # загрузка context.yaml
-│   ├── agent_core.py       # базовый класс агента
+│   ├── agent_core.py       # базовый класс агента-лица
 │   └── roles/
-│       ├── scout.py
-│       ├── architect.py
+│       ├── scout.py        # лицо: дарит карту кода
+│       ├── architect.py    # лицо: дарит план
 │       ├── backend_dev.py
 │       ├── frontend_dev.py
-│       ├── qa.py
-│       ├── security.py
+│       ├── qa.py           # вес 1.2
+│       ├── security.py     # вес 1.3 (блокирующий)
 │       ├── devops.py
 │       └── tech_writer.py
 ├── tests/
-│   ├── test_team_memory.py
-│   ├── test_agent_bus.py
-│   ├── test_project_context.py
-│   └── test_full_pipeline.py
-├── docs/
-│   ├── quickstart.md
-│   ├── integram_schema.md
-│   └── bus_protocol.md
-├── pyproject.toml
-└── README.md
-```
-
-Подключение в проекте:
-```bash
-pip install git+https://github.com/gaveron18/team-infra.git
+└── docs/
+    ├── quickstart.md
+    ├── gift_protocol.md    # протокол даров
+    └── integram_schema.md
 ```
 
 ---
@@ -245,48 +299,71 @@ pip install git+https://github.com/gaveron18/team-infra.git
 
 ### Фаза 0 — Основа (1 день)
 - [ ] Создать воркспейс `devteam` в Integram
-- [ ] Создать таблицы: PATTERNS, ANTIPATTERNS, DECISIONS, LESSONS, AGENT_BUS_LOG
-- [ ] Создать `docs/memory/context.yaml` для BEEBOT
+- [ ] Создать таблицы: PATTERNS, ANTIPATTERNS, DECISIONS, LESSONS, AGENT_BUS_LOG, TASK_LIFECYCLE
+- [ ] Создать `docs/memory/context.yaml` для BEEBOT (с telos и lifecycle_stage)
 - [ ] Создать репозиторий `gaveron18/team-infra`
 - [ ] Добавить `.agent_bus/` в `.gitignore`
 
-### Фаза 1 — Team Memory (3 дня)
-- [ ] `team_infra/team_memory.py` — Integram-клиент
+### Фаза 1 — Gift + Team Memory (3 дня)
+- [ ] `team_infra/gift.py` — Gift dataclass, GiftBus (файловая шина)
+- [ ] `team_infra/team_memory.py` — Integram devteam клиент
 - [ ] Заполнить начальные записи: 5 паттернов из BEEBOT, 5 ADR, 3 антипаттерна
-- [ ] `tests/test_team_memory.py` — запись / чтение / поиск
-- [ ] Все тесты зелёные
+- [ ] `tests/test_gift.py` + `tests/test_team_memory.py`
 
-### Фаза 2 — AgentBus (2 дня)
-- [ ] `team_infra/agent_bus.py` — файловая шина
-- [ ] Логирование в Integram `AGENT_BUS_LOG`
-- [ ] `tests/test_agent_bus.py` — Scout → Architect передача
-- [ ] Все тесты зелёные
+### Фаза 2 — Роли как лица (3 дня)
+- [ ] `team_infra/agent_core.py` — базовый класс с весом и призванием
+- [ ] `roles/scout.py` + `roles/architect.py` — первые два лица
+- [ ] `roles/security.py` — блокирующая роль (вес 1.3)
+- [ ] Первый реальный прогон: Scout → Architect на задаче из BEEBOT
 
-### Фаза 3 — Роли как код (3 дня)
-- [ ] `team_infra/agent_core.py` — базовый класс
-- [ ] `roles/scout.py` + `roles/architect.py` — машинные промты
-- [ ] Первый реальный прогон на задаче из BEEBOT
-- [ ] Документация: quickstart.md
+### Фаза 3 — Консенсус (2 дня)
+- [ ] Challenge-протокол (из TRADERAGENT): роли оспаривают решение Architect-а
+- [ ] Weighted voting: финальный скор с учётом весов
+- [ ] Штраф за противоречия (до 20%)
+- [ ] `tests/test_consensus.py`
 
-### Фаза 4 — Интеграция в BEEBOT (1 день)
+### Фаза 4 — Code Memory Graph (2 дня)
+- [ ] Граф анамнезиса в Integram (Neo4j): задача → паттерн → файл
+- [ ] `team_memory.remember_task(task, gifts)` — записать ЖЦ задачи
+- [ ] `team_memory.recall_anamnesis(task)` — найти со-присутствующие решения
+- [ ] `tests/test_graph.py`
+
+### Фаза 5 — Интеграция в BEEBOT (1 день)
 - [ ] `pip install team-infra` в BEEBOT
-- [ ] Scout + Architect запускаются как субагенты
-- [ ] Проверка на реальной задаче из plan.md
+- [ ] `context.yaml` обновлён
+- [ ] Scout + Architect запускаются как субагенты через Agent tool
+- [ ] Полный прогон: телос → дары → консенсус → деплой
 
-### Фаза 5 — Переосмысление архитектуры BEEBOT
-- [ ] Полная команда с памятью и AgentBus
-- [ ] Scout исследует весь проект с нуля
-- [ ] Architect предлагает новую архитектуру
-- [ ] Консенсус → одобрение Андрея → реализация
+### Фаза 6 — Переосмысление архитектуры BEEBOT
+- [ ] Полная команда с памятью, GiftBus и Code Memory Graph
+- [ ] Scout исследует весь проект с нуля, записывает в граф
+- [ ] Architect предлагает новую архитектуру (с анамнезисом всех ADR)
+- [ ] Консенсус всех ролей → `human_decision_required: True` → одобрение Андрея
+- [ ] Реализация
+
+---
+
+## Паттерны из смежных проектов
+
+### Из TRADERAGENT (InvestmentCommittee):
+- **T.6 Weighted Consensus** — веса ролей, Security/QA блокируют независимо
+- **T.7 Challenge Protocol** — обязательный раунд атак перед принятием плана
+- **T.8 Redis транспорт** — заменить FileTransport на Redis в Фазе 3+ (когда параллельные задачи)
+
+### Из PLM-GIFT (unidel2035/plm):
+- **T.9 Gift Protocol** — дары вместо вызовов функций, A5 (свобода DEFERRED)
+- **T.10 Code Memory Graph** — граф анамнезиса вместо плоских таблиц
+- **T.11 Telos-иерархия** — явный приоритет телос > security > qa при конфликте
+- **T.12 Lifecycle задачи** — тропосы (In Design / In Review / Released / In Change)
 
 ---
 
 ## Требования безопасности
 
-- `context.yaml` — в git, без секретов (только `${ENV_VAR}` ссылки)
-- `.agent_bus/` — в `.gitignore`, временные данные
-- `devteam` Integram — отдельный токен, не смешивать с `bibot`
-- Локальный SQLite-fallback при недоступности Integram (Фаза 1+)
+- `context.yaml` — в git, только `${ENV_VAR}` ссылки, без секретов
+- `.agent_bus/` — в `.gitignore`
+- `telos_risk: CRITICAL` зоны — Scout обязателен, Architecture review обязателен
+- `devteam` Integram — отдельный токен от `bibot`
 
 ---
 
@@ -294,13 +371,14 @@ pip install git+https://github.com/gaveron18/team-infra.git
 
 | Метрика | Критерий |
 |---------|---------|
-| Scout как субагент | возвращает ScoutReport за < 2 мин |
-| Team Memory | паттерн записан → найден поиском в новой сессии |
-| AgentBus | Scout → Architect без потери данных |
+| Gift передаётся | Scout → Architect Gift с anamnesis, без потери |
+| Анамнезис работает | паттерн из задачи M.5 найден при выполнении M.6 |
+| Консенсус | Security DECLINED → задача не деплоится |
 | Новый проект | context.yaml + `pip install` → команда работает за 15 мин |
 | Переиспользование | 1 паттерн из BEEBOT применён в AnalizShum |
 
 ---
 
 *Файл: docs/team_infra_plan.md*
-*Связанные файлы: docs/team_infra_prompt.md, docs/memory/context.yaml, docs/team.md*
+*Связанные: docs/team_infra_prompt.md, docs/memory/context.yaml, docs/team.md*
+*Источники: PLM-GIFT (unidel2035/plm), TRADERAGENT (alekseymavai), dronedoc2026*

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,3 +50,6 @@ numpy>=1.24,<3.0
 # Testing
 pytest>=8.0,<10.0
 pytest-asyncio>=0.23,<2.0
+
+# PDF/DOCX conversion
+pdf2docx>=0.5.8

--- a/src/plugins/telegram.py
+++ b/src/plugins/telegram.py
@@ -64,6 +64,14 @@ class TelegramPlugin(Plugin):
         kb = c.require("kb")
         memory_svc = getattr(orchestrator, "_memory_svc", None)
 
+        # 0. docs_router (PDF↔DOCX управление инструкциями — только ADMIN)
+        from src.routers.docs import router as docs_router, setup_docs
+        from src.services.docs_service import DocsService
+        from src.config import ADMIN_IDS
+        docs_svc = DocsService()
+        setup_docs(docs_svc, self._bot, list(ADMIN_IDS or []))
+        dp.include_router(docs_router)
+
         # 1. admin_router (приоритет)
         from src.admin import router as admin_router, setup_admin
         setup_admin(self._bot, crm=crm, kb=kb, memory=memory_svc, auth=auth)

--- a/src/routers/docs.py
+++ b/src/routers/docs.py
@@ -1,0 +1,209 @@
+"""Роутер управления PDF-инструкциями через Telegram.
+
+Команды (только ADMIN):
+  /docs            — показать список инструкций с кнопками «Скачать DOCX»
+  [кнопка]         — отправить DOCX конкретной инструкции
+  [приём .docx]    — FSM замены: выбрать PDF → подтвердить → сохранить
+"""
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from aiogram import Router, Bot, F, types
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    FSInputFile,
+)
+
+from src.services.docs_service import DocsService
+
+logger = logging.getLogger(__name__)
+router = Router()
+
+_docs_svc: Optional[DocsService] = None
+_bot: Optional[Bot] = None
+_admin_ids: list[int] = []
+
+
+def setup_docs(docs_svc: DocsService, bot: Bot, admin_ids: list[int]) -> None:
+    global _docs_svc, _bot, _admin_ids
+    _docs_svc = docs_svc
+    _bot = bot
+    _admin_ids = admin_ids
+
+
+class DocsUploadFSM(StatesGroup):
+    waiting_for_target = State()
+    waiting_for_confirm = State()
+
+
+def _is_admin(user_id: int) -> bool:
+    return user_id in _admin_ids
+
+
+def _build_docs_keyboard() -> InlineKeyboardMarkup:
+    buttons = [
+        [InlineKeyboardButton(
+            text=f"📄 {name}",
+            callback_data=f"docs:get:{name}",
+        )]
+        for name in (_docs_svc.list_pdfs() if _docs_svc else [])
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
+@router.message(Command("docs"))
+async def cmd_docs(message: types.Message) -> None:
+    if not _is_admin(message.from_user.id):
+        return
+    names = _docs_svc.list_pdfs()
+    if not names:
+        await message.answer("Инструкции не найдены в data/pdfs/")
+        return
+    await message.answer(
+        f"📚 <b>Инструкции</b> ({len(names)} шт.)\n\nНажмите чтобы скачать как DOCX:",
+        reply_markup=_build_docs_keyboard(),
+        parse_mode="HTML",
+    )
+
+
+@router.callback_query(F.data.startswith("docs:get:"))
+async def cb_get_docx(callback: types.CallbackQuery) -> None:
+    if not _is_admin(callback.from_user.id):
+        await callback.answer("Нет доступа")
+        return
+
+    name = callback.data.removeprefix("docs:get:")
+    await callback.answer("Конвертирую...")
+    await callback.message.answer(f"⏳ Конвертирую «{name}» в DOCX...")
+
+    try:
+        docx_path = _docs_svc.pdf_to_docx(name)
+    except FileNotFoundError:
+        await callback.message.answer(f"❌ Файл «{name}.pdf» не найден")
+        return
+    except Exception as e:
+        logger.exception("Ошибка конвертации PDF→DOCX: %s", e)
+        await callback.message.answer(f"❌ Ошибка конвертации: {e}")
+        return
+
+    await callback.message.answer_document(
+        FSInputFile(str(docx_path), filename=f"{name}.docx"),
+        caption=(
+            f"📝 <b>{name}</b>\n\n"
+            "Отредактируйте и отправьте DOCX обратно — "
+            "сохраню в PDF и обновлю базу знаний."
+        ),
+        parse_mode="HTML",
+    )
+
+
+DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+
+@router.message(F.document.mime_type == DOCX_MIME)
+async def receive_docx(message: types.Message, state: FSMContext) -> None:
+    if not _is_admin(message.from_user.id):
+        return
+
+    names = _docs_svc.list_pdfs()
+    if not names:
+        await message.answer("❌ Нет PDF-инструкций для замены")
+        return
+
+    await state.update_data(
+        docx_file_id=message.document.file_id,
+        docx_filename=message.document.file_name or "document.docx",
+    )
+    await state.set_state(DocsUploadFSM.waiting_for_target)
+
+    stem = Path(message.document.file_name or "").stem
+    exact_match = stem if stem in names else None
+
+    if exact_match:
+        await state.update_data(target_name=exact_match)
+        await state.set_state(DocsUploadFSM.waiting_for_confirm)
+        kb = InlineKeyboardMarkup(inline_keyboard=[[
+            InlineKeyboardButton(text="✅ Да, заменить", callback_data="docs:confirm:yes"),
+            InlineKeyboardButton(text="❌ Отмена", callback_data="docs:confirm:no"),
+        ]])
+        await message.answer(
+            f"Заменить инструкцию <b>«{exact_match}»</b>?",
+            reply_markup=kb,
+            parse_mode="HTML",
+        )
+    else:
+        buttons = [
+            [InlineKeyboardButton(text=n, callback_data=f"docs:target:{n}")]
+            for n in names
+        ]
+        buttons.append([InlineKeyboardButton(text="❌ Отмена", callback_data="docs:confirm:no")])
+        await message.answer(
+            "Какую инструкцию заменить?",
+            reply_markup=InlineKeyboardMarkup(inline_keyboard=buttons),
+        )
+
+
+@router.callback_query(DocsUploadFSM.waiting_for_target, F.data.startswith("docs:target:"))
+async def cb_select_target(callback: types.CallbackQuery, state: FSMContext) -> None:
+    target = callback.data.removeprefix("docs:target:")
+    await state.update_data(target_name=target)
+    await state.set_state(DocsUploadFSM.waiting_for_confirm)
+    kb = InlineKeyboardMarkup(inline_keyboard=[[
+        InlineKeyboardButton(text="✅ Да, заменить", callback_data="docs:confirm:yes"),
+        InlineKeyboardButton(text="❌ Отмена", callback_data="docs:confirm:no"),
+    ]])
+    await callback.message.edit_text(
+        f"Заменить инструкцию <b>«{target}»</b>?",
+        reply_markup=kb,
+        parse_mode="HTML",
+    )
+    await callback.answer()
+
+
+@router.callback_query(DocsUploadFSM.waiting_for_confirm, F.data == "docs:confirm:no")
+async def cb_cancel(callback: types.CallbackQuery, state: FSMContext) -> None:
+    await state.clear()
+    await callback.message.edit_text("Отменено.")
+    await callback.answer()
+
+
+@router.callback_query(DocsUploadFSM.waiting_for_confirm, F.data == "docs:confirm:yes")
+async def cb_confirm_save(callback: types.CallbackQuery, state: FSMContext) -> None:
+    data = await state.get_data()
+    await state.clear()
+    await callback.message.edit_text("⏳ Конвертирую и сохраняю...")
+    await callback.answer()
+
+    target_name: str = data["target_name"]
+    file_id: str = data["docx_file_id"]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_docx = Path(tmpdir) / f"{target_name}.docx"
+        await _bot.download(file_id, destination=str(tmp_docx))
+
+        try:
+            _docs_svc.docx_to_pdf(tmp_docx, dest_name=target_name)
+        except Exception as e:
+            logger.exception("Ошибка DOCX→PDF: %s", e)
+            await callback.message.answer(f"❌ Ошибка конвертации: {e}")
+            return
+
+    await callback.message.answer(
+        f"✅ Инструкция <b>«{target_name}»</b> сохранена.\n⏳ Обновляю базу знаний...",
+        parse_mode="HTML",
+    )
+
+    try:
+        await _docs_svc.rebuild_kb()
+        await callback.message.answer("✅ База знаний обновлена!")
+    except Exception as e:
+        logger.exception("Ошибка пересборки KB: %s", e)
+        await callback.message.answer(f"⚠️ PDF сохранён, но KB не обновлена: {e}")

--- a/src/routers/docs.py
+++ b/src/routers/docs.py
@@ -63,6 +63,8 @@ def _build_docs_keyboard() -> InlineKeyboardMarkup:
 async def cmd_docs(message: types.Message) -> None:
     if not _is_admin(message.from_user.id):
         return
+    if not _docs_svc:
+        return
     names = _docs_svc.list_pdfs()
     if not names:
         await message.answer("Инструкции не найдены в data/pdfs/")
@@ -153,6 +155,9 @@ async def receive_docx(message: types.Message, state: FSMContext) -> None:
 
 @router.callback_query(DocsUploadFSM.waiting_for_target, F.data.startswith("docs:target:"))
 async def cb_select_target(callback: types.CallbackQuery, state: FSMContext) -> None:
+    if not _is_admin(callback.from_user.id):
+        await callback.answer("Нет доступа")
+        return
     target = callback.data.removeprefix("docs:target:")
     await state.update_data(target_name=target)
     await state.set_state(DocsUploadFSM.waiting_for_confirm)
@@ -170,6 +175,9 @@ async def cb_select_target(callback: types.CallbackQuery, state: FSMContext) -> 
 
 @router.callback_query(DocsUploadFSM.waiting_for_confirm, F.data == "docs:confirm:no")
 async def cb_cancel(callback: types.CallbackQuery, state: FSMContext) -> None:
+    if not _is_admin(callback.from_user.id):
+        await callback.answer("Нет доступа")
+        return
     await state.clear()
     await callback.message.edit_text("Отменено.")
     await callback.answer()
@@ -177,6 +185,9 @@ async def cb_cancel(callback: types.CallbackQuery, state: FSMContext) -> None:
 
 @router.callback_query(DocsUploadFSM.waiting_for_confirm, F.data == "docs:confirm:yes")
 async def cb_confirm_save(callback: types.CallbackQuery, state: FSMContext) -> None:
+    if not _is_admin(callback.from_user.id):
+        await callback.answer("Нет доступа")
+        return
     data = await state.get_data()
     await state.clear()
     await callback.message.edit_text("⏳ Конвертирую и сохраняю...")
@@ -187,7 +198,12 @@ async def cb_confirm_save(callback: types.CallbackQuery, state: FSMContext) -> N
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_docx = Path(tmpdir) / f"{target_name}.docx"
-        await _bot.download(file_id, destination=str(tmp_docx))
+        try:
+            await _bot.download(file_id, destination=str(tmp_docx))
+        except Exception as e:
+            logger.exception("Ошибка скачивания файла: %s", e)
+            await callback.message.answer(f"❌ Не удалось скачать файл: {e}")
+            return
 
         try:
             _docs_svc.docx_to_pdf(tmp_docx, dest_name=target_name)

--- a/src/routers/docs.py
+++ b/src/routers/docs.py
@@ -83,6 +83,13 @@ async def cb_get_docx(callback: types.CallbackQuery) -> None:
         return
 
     name = callback.data.removeprefix("docs:get:")
+
+    # Защита от path traversal
+    if name not in _docs_svc.list_pdfs():
+        await callback.message.answer(f"❌ Инструкция «{name}» не найдена")
+        await callback.answer()
+        return
+
     await callback.answer("Конвертирую...")
     await callback.message.answer(f"⏳ Конвертирую «{name}» в DOCX...")
 
@@ -151,6 +158,16 @@ async def receive_docx(message: types.Message, state: FSMContext) -> None:
             "Какую инструкцию заменить?",
             reply_markup=InlineKeyboardMarkup(inline_keyboard=buttons),
         )
+
+
+@router.callback_query(DocsUploadFSM.waiting_for_target, F.data == "docs:confirm:no")
+async def cb_cancel_target(callback: types.CallbackQuery, state: FSMContext) -> None:
+    if not _is_admin(callback.from_user.id):
+        await callback.answer("Нет доступа")
+        return
+    await state.clear()
+    await callback.message.edit_text("Отменено.")
+    await callback.answer()
 
 
 @router.callback_query(DocsUploadFSM.waiting_for_target, F.data.startswith("docs:target:"))

--- a/src/services/docs_service.py
+++ b/src/services/docs_service.py
@@ -1,0 +1,79 @@
+"""Сервис управления PDF-инструкциями: конвертация PDF↔DOCX, список, сохранение."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_PDFS_DIR = Path("data/pdfs")
+_WORD_DIR = Path("data/docs_word")
+
+
+class DocsService:
+    """Конвертация и хранение инструкций."""
+
+    def __init__(
+        self,
+        pdfs_dir: Path = _PDFS_DIR,
+        word_dir: Path = _WORD_DIR,
+    ) -> None:
+        self.pdfs_dir = pdfs_dir
+        self.word_dir = word_dir
+        self.word_dir.mkdir(parents=True, exist_ok=True)
+
+    def list_pdfs(self) -> list[str]:
+        """Вернуть отсортированный список имён инструкций (без .pdf)."""
+        return sorted(p.stem for p in self.pdfs_dir.glob("*.pdf"))
+
+    def pdf_to_docx(self, name: str) -> Path:
+        """Конвертировать PDF → DOCX. Кешируется в word_dir."""
+        pdf_path = self.pdfs_dir / f"{name}.pdf"
+        if not pdf_path.exists():
+            raise FileNotFoundError(f"{name}: PDF не найден в {self.pdfs_dir}")
+
+        from pdf2docx import Converter  # lazy import
+
+        docx_path = self.word_dir / f"{name}.docx"
+        with Converter(str(pdf_path)) as cv:
+            cv.convert(str(docx_path), start=0, end=None)
+        return docx_path
+
+    def docx_to_pdf(self, docx_path: Path, dest_name: str) -> Path:
+        """Конвертировать DOCX → PDF через LibreOffice headless."""
+        result = subprocess.run(
+            [
+                "libreoffice",
+                "--headless",
+                "--convert-to", "pdf",
+                "--outdir", str(self.word_dir),
+                str(docx_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"LibreOffice завершился с ошибкой: {result.stderr}")
+
+        converted = self.word_dir / f"{docx_path.stem}.pdf"
+        dest = self.pdfs_dir / f"{dest_name}.pdf"
+        converted.replace(dest)
+        logger.info("Сохранён PDF: %s", dest)
+        return dest
+
+    async def rebuild_kb(self) -> None:
+        """Пересобрать FAISS-индекс базы знаний (src.build_kb)."""
+        logger.info("Запуск пересборки KB...")
+        proc = await asyncio.create_subprocess_exec(
+            "python", "-m", "src.build_kb",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            logger.error("Ошибка пересборки KB: %s", stderr.decode())
+        else:
+            logger.info("KB пересобрана успешно: %s", stdout.decode()[:200])

--- a/src/services/docs_service.py
+++ b/src/services/docs_service.py
@@ -43,6 +43,8 @@ class DocsService:
 
     def docx_to_pdf(self, docx_path: Path, dest_name: str) -> Path:
         """Конвертировать DOCX → PDF через LibreOffice headless."""
+        if not docx_path.exists():
+            raise FileNotFoundError(f"DOCX не найден: {docx_path}")
         result = subprocess.run(
             [
                 "libreoffice",
@@ -75,5 +77,6 @@ class DocsService:
         stdout, stderr = await proc.communicate()
         if proc.returncode != 0:
             logger.error("Ошибка пересборки KB: %s", stderr.decode())
+            raise RuntimeError(f"Ошибка пересборки KB: {stderr.decode()}")
         else:
             logger.info("KB пересобрана успешно: %s", stdout.decode()[:200])

--- a/tests/test_docs_service.py
+++ b/tests/test_docs_service.py
@@ -1,0 +1,95 @@
+import asyncio
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from src.services.docs_service import DocsService
+
+
+@pytest.fixture
+def tmp_pdfs(tmp_path):
+    """Создаём 2 тестовых PDF-файла."""
+    (tmp_path / "Перга.pdf").write_bytes(b"%PDF-1.4 test")
+    (tmp_path / "Прополис.pdf").write_bytes(b"%PDF-1.4 test")
+    return tmp_path
+
+
+def test_list_pdfs_returns_sorted_names(tmp_pdfs):
+    svc = DocsService(pdfs_dir=tmp_pdfs, word_dir=tmp_pdfs / "word")
+    names = svc.list_pdfs()
+    assert names == ["Перга", "Прополис"]
+
+
+def test_list_pdfs_empty_dir(tmp_path):
+    svc = DocsService(pdfs_dir=tmp_path, word_dir=tmp_path / "word")
+    assert svc.list_pdfs() == []
+
+
+def test_pdf_to_docx_returns_path(tmp_pdfs):
+    svc = DocsService(pdfs_dir=tmp_pdfs, word_dir=tmp_pdfs / "word")
+
+    with patch("src.services.docs_service.DocsService.pdf_to_docx") as mock_conv:
+        expected = tmp_pdfs / "word" / "Перга.docx"
+        mock_conv.return_value = expected
+        result = svc.pdf_to_docx("Перга")
+
+    assert result.suffix == ".docx"
+    assert result.stem == "Перга"
+
+
+def test_pdf_to_docx_raises_if_not_found(tmp_pdfs):
+    svc = DocsService(pdfs_dir=tmp_pdfs, word_dir=tmp_pdfs / "word")
+    with pytest.raises(FileNotFoundError, match="Несуществующий"):
+        svc.pdf_to_docx("Несуществующий")
+
+
+def test_docx_to_pdf_calls_libreoffice(tmp_pdfs):
+    svc = DocsService(pdfs_dir=tmp_pdfs, word_dir=tmp_pdfs / "word")
+    docx_file = tmp_pdfs / "word" / "Перга.docx"
+    svc.word_dir.mkdir(parents=True, exist_ok=True)
+    docx_file.write_bytes(b"PK fake docx content")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stderr = ""
+        # LibreOffice создаёт PDF рядом с DOCX
+        (tmp_pdfs / "word" / "Перга.pdf").write_bytes(b"%PDF-1.4")
+        result = svc.docx_to_pdf(docx_file, dest_name="Перга")
+
+    mock_run.assert_called_once()
+    cmd = mock_run.call_args[0][0]
+    assert "libreoffice" in cmd
+    assert "--convert-to" in cmd
+    assert "pdf" in cmd
+    assert result == tmp_pdfs / "Перга.pdf"
+
+
+def test_docx_to_pdf_raises_on_failure(tmp_pdfs):
+    svc = DocsService(pdfs_dir=tmp_pdfs, word_dir=tmp_pdfs / "word")
+    docx_file = tmp_pdfs / "word" / "Test.docx"
+    svc.word_dir.mkdir(parents=True, exist_ok=True)
+    docx_file.write_bytes(b"PK fake")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = "libreoffice error"
+        with pytest.raises(RuntimeError, match="LibreOffice"):
+            svc.docx_to_pdf(docx_file, dest_name="Test")
+
+
+@pytest.mark.asyncio
+async def test_rebuild_kb_runs_module(tmp_pdfs):
+    svc = DocsService(pdfs_dir=tmp_pdfs, word_dir=tmp_pdfs / "word")
+
+    mock_proc = MagicMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"ok", b""))
+    mock_proc.returncode = 0
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+        await svc.rebuild_kb()
+
+    mock_exec.assert_called_once_with(
+        "python", "-m", "src.build_kb",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )

--- a/tests/test_docs_service.py
+++ b/tests/test_docs_service.py
@@ -26,15 +26,27 @@ def test_list_pdfs_empty_dir(tmp_path):
 
 
 def test_pdf_to_docx_returns_path(tmp_pdfs):
+    """pdf_to_docx должен вернуть путь к DOCX в word_dir."""
+    import sys
+    import types
+
     svc = DocsService(pdfs_dir=tmp_pdfs, word_dir=tmp_pdfs / "word")
 
-    with patch("src.services.docs_service.DocsService.pdf_to_docx") as mock_conv:
-        expected = tmp_pdfs / "word" / "Перга.docx"
-        mock_conv.return_value = expected
+    mock_instance = MagicMock()
+    mock_instance.__enter__ = MagicMock(return_value=mock_instance)
+    mock_instance.__exit__ = MagicMock(return_value=False)
+    mock_instance.convert.return_value = None
+
+    MockConverter = MagicMock(return_value=mock_instance)
+
+    fake_pdf2docx = types.ModuleType("pdf2docx")
+    fake_pdf2docx.Converter = MockConverter
+
+    with patch.dict(sys.modules, {"pdf2docx": fake_pdf2docx}):
         result = svc.pdf_to_docx("Перга")
 
-    assert result.suffix == ".docx"
-    assert result.stem == "Перга"
+    assert result == tmp_pdfs / "word" / "Перга.docx"
+    assert result.parent == tmp_pdfs / "word"
 
 
 def test_pdf_to_docx_raises_if_not_found(tmp_pdfs):
@@ -75,6 +87,19 @@ def test_docx_to_pdf_raises_on_failure(tmp_pdfs):
         mock_run.return_value.stderr = "libreoffice error"
         with pytest.raises(RuntimeError, match="LibreOffice"):
             svc.docx_to_pdf(docx_file, dest_name="Test")
+
+
+@pytest.mark.asyncio
+async def test_rebuild_kb_raises_on_failure(tmp_pdfs):
+    svc = DocsService(pdfs_dir=tmp_pdfs, word_dir=tmp_pdfs / "word")
+
+    mock_proc = MagicMock()
+    mock_proc.communicate = AsyncMock(return_value=(b"", b"build error"))
+    mock_proc.returncode = 1
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        with pytest.raises(RuntimeError, match="Ошибка пересборки KB"):
+            await svc.rebuild_kb()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Новая команда `/docs` для скачивания PDF-инструкций в формате DOCX
- FSM приёма отредактированного DOCX обратно: автоматическое определение файла → подтверждение → конвертация → сохранение → пересборка базы знаний
- Конвертация PDF→DOCX через `pdf2docx`, DOCX→PDF через LibreOffice headless

## Changes

- `src/services/docs_service.py` — новый сервис конвертации
- `src/routers/docs.py` — роутер `/docs` + FSM (только ADMIN_CHAT_ID)
- `src/plugins/telegram.py` — подключен `docs_router`
- `Dockerfile` — добавлен `libreoffice-writer`
- `requirements.txt` — добавлен `pdf2docx>=0.5.8`
- `docker-compose.yml` — volumes для `data/pdfs` и `data/docs_word`

## Test Plan

- [ ] 8/8 тестов `pytest tests/test_docs_service.py` проходят
- [ ] `/docs` показывает список инструкций с кнопками
- [ ] Кнопка отправляет `.docx` файл
- [ ] Отправка DOCX обратно → выбор цели → подтверждение → PDF сохранён
- [ ] После сохранения KB пересобирается автоматически
- [ ] Кнопка «Отмена» работает в обоих состояниях FSM