### PR TITLE
fix(kernel): исправить ошибки старта микроядра (PR #200)

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -254,6 +254,12 @@ class Orchestrator:
         """Инжектировать CrmAgent после создания IntegramClient (вызывается из bot.py)."""
         self._crm_agent = crm_agent
 
+    def set_kb(self, kb) -> None:
+        """Инжектировать готовую KnowledgeBase из контейнера (микроядро)."""
+        from src.services.consult_service import ConsultService
+        self._beebot.kb = kb
+        self._beebot._service = ConsultService(kb, self._beebot.llm)
+
     def set_agent_specs(self, agent_specs) -> None:
         """Инжектировать AgentSpecsCache после загрузки (вызывается из bot.py)."""
         self._agent_specs = agent_specs

--- a/src/plugins/gift.py
+++ b/src/plugins/gift.py
@@ -38,7 +38,7 @@ class GiftPlugin(Plugin):
         crm_agent = CrmAgent(crm)
         orchestrator.set_crm_agent(crm_agent)
 
-        anamnesis = AnamnesisCache(orchestrator._memory)
+        anamnesis = AnamnesisCache(orchestrator._memory_svc)
 
         gift_broker = GiftBroker(
             orchestrator=orchestrator,

--- a/src/plugins/web.py
+++ b/src/plugins/web.py
@@ -33,12 +33,12 @@ class WebPlugin(Plugin):
         self._container: Optional["Container"] = None
 
     async def setup(self, container: "Container") -> None:
-        from src.web.api import create_app
+        from src.web.api import app as fastapi_app_module
 
         self._container = container
 
         # Создать FastAPI приложение
-        fastapi_app = create_app()
+        fastapi_app = fastapi_app_module
         container.set("fastapi_app", fastapi_app)
 
         # Инжектировать сервисы в веб-приложение


### PR DESCRIPTION
## Summary

Три ошибки `AttributeError` / `ImportError` при старте бота, введённые в PR #200 (микроядерная архитектура):

- `Orchestrator` не имел метода `set_kb()` — вызывается из `AgentsPlugin` → добавлен
- `gift.py` обращался к `orchestrator._memory` — атрибут переименован в `_memory_svc` → исправлено
- `web.py` импортировал несуществующую `create_app()` — в `api.py` есть module-level `app` → исправлено

## Test Plan

- [ ] Бот стартует без ошибок (`docker logs beebot`)
- [ ] Uvicorn запущен на :8088
- [ ] Polling `@AleksandrDmitrov_BEEBOT` активен