### PR TITLE
feat(docs): добавить новую инструкцию через бота (PDF или DOCX)

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -254,6 +254,12 @@ class Orchestrator:
         """Инжектировать CrmAgent после создания IntegramClient (вызывается из bot.py)."""
         self._crm_agent = crm_agent
 
+    def set_kb(self, kb) -> None:
+        """Инжектировать готовую KnowledgeBase из контейнера (микроядро)."""
+        from src.services.consult_service import ConsultService
+        self._beebot.kb = kb
+        self._beebot._service = ConsultService(kb, self._beebot.llm)
+
     def set_agent_specs(self, agent_specs) -> None:
         """Инжектировать AgentSpecsCache после загрузки (вызывается из bot.py)."""
         self._agent_specs = agent_specs

--- a/src/plugins/gift.py
+++ b/src/plugins/gift.py
@@ -38,7 +38,7 @@ class GiftPlugin(Plugin):
         crm_agent = CrmAgent(crm)
         orchestrator.set_crm_agent(crm_agent)
 
-        anamnesis = AnamnesisCache(orchestrator._memory)
+        anamnesis = AnamnesisCache(orchestrator._memory_svc)
 
         gift_broker = GiftBroker(
             orchestrator=orchestrator,

--- a/src/plugins/web.py
+++ b/src/plugins/web.py
@@ -33,12 +33,12 @@ class WebPlugin(Plugin):
         self._container: Optional["Container"] = None
 
     async def setup(self, container: "Container") -> None:
-        from src.web.api import create_app
+        from src.web.api import app as fastapi_app_module
 
         self._container = container
 
         # Создать FastAPI приложение
-        fastapi_app = create_app()
+        fastapi_app = fastapi_app_module
         container.set("fastapi_app", fastapi_app)
 
         # Инжектировать сервисы в веб-приложение

--- a/src/routers/docs.py
+++ b/src/routers/docs.py
@@ -48,13 +48,26 @@ def _is_admin(user_id: int) -> bool:
     return user_id in _admin_ids
 
 
-def _build_docs_keyboard() -> InlineKeyboardMarkup:
+# Индекс: short_id → полное имя (перестраивается при каждом /docs)
+# Telegram лимит callback_data = 64 байта, длинные кириллические имена не влезают
+_docs_idx: dict[str, str] = {}
+
+
+def _rebuild_index() -> list[str]:
+    """Перестроить индекс имён и вернуть список имён."""
+    global _docs_idx
+    names = _docs_svc.list_pdfs() if _docs_svc else []
+    _docs_idx = {str(i): name for i, name in enumerate(names)}
+    return names
+
+
+def _build_docs_keyboard(names: list[str]) -> InlineKeyboardMarkup:
     buttons = [
         [InlineKeyboardButton(
             text=f"📄 {name}",
-            callback_data=f"docs:get:{name}",
+            callback_data=f"docs:get:{i}",
         )]
-        for name in (_docs_svc.list_pdfs() if _docs_svc else [])
+        for i, name in enumerate(names)
     ]
     return InlineKeyboardMarkup(inline_keyboard=buttons)
 
@@ -65,13 +78,13 @@ async def cmd_docs(message: types.Message) -> None:
         return
     if not _docs_svc:
         return
-    names = _docs_svc.list_pdfs()
+    names = _rebuild_index()
     if not names:
         await message.answer("Инструкции не найдены в data/pdfs/")
         return
     await message.answer(
         f"📚 <b>Инструкции</b> ({len(names)} шт.)\n\nНажмите чтобы скачать как DOCX:",
-        reply_markup=_build_docs_keyboard(),
+        reply_markup=_build_docs_keyboard(names),
         parse_mode="HTML",
     )
 
@@ -82,11 +95,11 @@ async def cb_get_docx(callback: types.CallbackQuery) -> None:
         await callback.answer("Нет доступа")
         return
 
-    name = callback.data.removeprefix("docs:get:")
+    idx = callback.data.removeprefix("docs:get:")
+    name = _docs_idx.get(idx)
 
-    # Защита от path traversal
-    if name not in _docs_svc.list_pdfs():
-        await callback.message.answer(f"❌ Инструкция «{name}» не найдена")
+    if not name or name not in _docs_svc.list_pdfs():
+        await callback.message.answer("❌ Инструкция не найдена. Повторите /docs")
         await callback.answer()
         return
 
@@ -149,9 +162,10 @@ async def receive_docx(message: types.Message, state: FSMContext) -> None:
             parse_mode="HTML",
         )
     else:
+        _rebuild_index()
         buttons = [
-            [InlineKeyboardButton(text=n, callback_data=f"docs:target:{n}")]
-            for n in names
+            [InlineKeyboardButton(text=n, callback_data=f"docs:target:{i}")]
+            for i, n in enumerate(names)
         ]
         buttons.append([InlineKeyboardButton(text="❌ Отмена", callback_data="docs:confirm:no")])
         await message.answer(
@@ -175,7 +189,12 @@ async def cb_select_target(callback: types.CallbackQuery, state: FSMContext) -> 
     if not _is_admin(callback.from_user.id):
         await callback.answer("Нет доступа")
         return
-    target = callback.data.removeprefix("docs:target:")
+    idx = callback.data.removeprefix("docs:target:")
+    target = _docs_idx.get(idx)
+    if not target:
+        await callback.message.edit_text("❌ Инструкция не найдена. Повторите /docs")
+        await callback.answer()
+        return
     await state.update_data(target_name=target)
     await state.set_state(DocsUploadFSM.waiting_for_confirm)
     kb = InlineKeyboardMarkup(inline_keyboard=[[

--- a/src/routers/docs.py
+++ b/src/routers/docs.py
@@ -42,6 +42,8 @@ def setup_docs(docs_svc: DocsService, bot: Bot, admin_ids: list[int]) -> None:
 class DocsUploadFSM(StatesGroup):
     waiting_for_target = State()
     waiting_for_confirm = State()
+    waiting_for_new_file = State()
+    waiting_for_new_confirm = State()
 
 
 def _is_admin(user_id: int) -> bool:
@@ -69,6 +71,7 @@ def _build_docs_keyboard(names: list[str]) -> InlineKeyboardMarkup:
         )]
         for i, name in enumerate(names)
     ]
+    buttons.append([InlineKeyboardButton(text="➕ Добавить новую инструкцию", callback_data="docs:new")])
     return InlineKeyboardMarkup(inline_keyboard=buttons)
 
 
@@ -259,3 +262,115 @@ async def cb_confirm_save(callback: types.CallbackQuery, state: FSMContext) -> N
     except Exception as e:
         logger.exception("Ошибка пересборки KB: %s", e)
         await callback.message.answer(f"⚠️ PDF сохранён, но KB не обновлена: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Добавление новой инструкции
+# ---------------------------------------------------------------------------
+
+@router.callback_query(F.data == "docs:new")
+async def cb_new_doc(callback: types.CallbackQuery, state: FSMContext) -> None:
+    if not _is_admin(callback.from_user.id):
+        await callback.answer("Нет доступа")
+        return
+    await state.set_state(DocsUploadFSM.waiting_for_new_file)
+    await callback.message.answer(
+        "📎 Отправьте файл новой инструкции (PDF или DOCX).\n"
+        "Имя файла станет названием инструкции."
+    )
+    await callback.answer()
+
+
+PDF_MIME = "application/pdf"
+
+
+@router.message(DocsUploadFSM.waiting_for_new_file, F.document.mime_type == PDF_MIME)
+async def receive_new_pdf(message: types.Message, state: FSMContext) -> None:
+    if not _is_admin(message.from_user.id):
+        return
+    name = Path(message.document.file_name or "новая_инструкция.pdf").stem
+    await state.update_data(new_file_id=message.document.file_id, new_name=name, new_is_docx=False)
+    await state.set_state(DocsUploadFSM.waiting_for_new_confirm)
+    kb = InlineKeyboardMarkup(inline_keyboard=[[
+        InlineKeyboardButton(text="✅ Добавить", callback_data="docs:new:yes"),
+        InlineKeyboardButton(text="❌ Отмена", callback_data="docs:new:no"),
+    ]])
+    await message.answer(
+        f"Добавить инструкцию <b>«{name}»</b>?",
+        reply_markup=kb,
+        parse_mode="HTML",
+    )
+
+
+@router.message(DocsUploadFSM.waiting_for_new_file, F.document.mime_type == DOCX_MIME)
+async def receive_new_docx(message: types.Message, state: FSMContext) -> None:
+    if not _is_admin(message.from_user.id):
+        return
+    name = Path(message.document.file_name or "новая_инструкция.docx").stem
+    await state.update_data(new_file_id=message.document.file_id, new_name=name, new_is_docx=True)
+    await state.set_state(DocsUploadFSM.waiting_for_new_confirm)
+    kb = InlineKeyboardMarkup(inline_keyboard=[[
+        InlineKeyboardButton(text="✅ Добавить", callback_data="docs:new:yes"),
+        InlineKeyboardButton(text="❌ Отмена", callback_data="docs:new:no"),
+    ]])
+    await message.answer(
+        f"Добавить инструкцию <b>«{name}»</b>?",
+        reply_markup=kb,
+        parse_mode="HTML",
+    )
+
+
+@router.callback_query(DocsUploadFSM.waiting_for_new_confirm, F.data == "docs:new:no")
+async def cb_new_cancel(callback: types.CallbackQuery, state: FSMContext) -> None:
+    if not _is_admin(callback.from_user.id):
+        await callback.answer("Нет доступа")
+        return
+    await state.clear()
+    await callback.message.edit_text("Отменено.")
+    await callback.answer()
+
+
+@router.callback_query(DocsUploadFSM.waiting_for_new_confirm, F.data == "docs:new:yes")
+async def cb_new_confirm(callback: types.CallbackQuery, state: FSMContext) -> None:
+    if not _is_admin(callback.from_user.id):
+        await callback.answer("Нет доступа")
+        return
+    data = await state.get_data()
+    await state.clear()
+    await callback.message.edit_text("⏳ Сохраняю...")
+    await callback.answer()
+
+    name: str = data["new_name"]
+    file_id: str = data["new_file_id"]
+    is_docx: bool = data["new_is_docx"]
+    ext = ".docx" if is_docx else ".pdf"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_file = Path(tmpdir) / f"{name}{ext}"
+        try:
+            await _bot.download(file_id, destination=str(tmp_file))
+        except Exception as e:
+            logger.exception("Ошибка скачивания: %s", e)
+            await callback.message.answer(f"❌ Не удалось скачать файл: {e}")
+            return
+
+        try:
+            if is_docx:
+                _docs_svc.docx_to_pdf(tmp_file, dest_name=name)
+            else:
+                _docs_svc.save_pdf(tmp_file, dest_name=name)
+        except Exception as e:
+            logger.exception("Ошибка сохранения: %s", e)
+            await callback.message.answer(f"❌ Ошибка сохранения: {e}")
+            return
+
+    await callback.message.answer(
+        f"✅ Инструкция <b>«{name}»</b> добавлена.\n⏳ Обновляю базу знаний...",
+        parse_mode="HTML",
+    )
+    try:
+        await _docs_svc.rebuild_kb()
+        await callback.message.answer("✅ База знаний обновлена!")
+    except Exception as e:
+        logger.exception("Ошибка пересборки KB: %s", e)
+        await callback.message.answer(f"⚠️ Файл сохранён, но KB не обновлена: {e}")

--- a/src/services/docs_service.py
+++ b/src/services/docs_service.py
@@ -83,3 +83,11 @@ class DocsService:
             raise RuntimeError(f"Ошибка пересборки KB: {stderr.decode()}")
         else:
             logger.info("KB пересобрана успешно: %s", stdout.decode()[:200])
+
+    def save_pdf(self, src_path: Path, dest_name: str) -> Path:
+        """Сохранить готовый PDF под именем dest_name в pdfs_dir."""
+        dest = self.pdfs_dir / f"{dest_name}.pdf"
+        import shutil
+        shutil.copy2(src_path, dest)
+        logger.info("Сохранён новый PDF: %s", dest)
+        return dest

--- a/src/services/docs_service.py
+++ b/src/services/docs_service.py
@@ -37,8 +37,11 @@ class DocsService:
         from pdf2docx import Converter  # lazy import
 
         docx_path = self.word_dir / f"{name}.docx"
-        with Converter(str(pdf_path)) as cv:
+        cv = Converter(str(pdf_path))
+        try:
             cv.convert(str(docx_path), start=0, end=None)
+        finally:
+            cv.close()
         return docx_path
 
     def docx_to_pdf(self, docx_path: Path, dest_name: str) -> Path:


### PR DESCRIPTION
Кнопка «➕ Добавить новую инструкцию» в /docs. Принимает PDF или DOCX, DOCX конвертируется через LibreOffice, имя файла = название инструкции. После сохранения пересобирает KB.